### PR TITLE
feat: DocumentStore - doc_id 与树结构持久化 (Issue #2)

### DIFF
--- a/pageindex_rag/storage/document_store.py
+++ b/pageindex_rag/storage/document_store.py
@@ -1,0 +1,67 @@
+"""DocumentStore: CRUD operations for PageIndex documents in PostgreSQL."""
+
+import json
+import os
+import uuid
+
+from pageindex_rag.storage.models import Document
+
+
+class DocumentStore:
+    """Stores and retrieves PageIndex tree structures."""
+
+    def __init__(self, session_factory):
+        self._Session = session_factory
+
+    def create(self, pdf_path: str, tree_json: dict) -> str:
+        """Store a document and return its doc_id."""
+        doc_id = f"pi-{uuid.uuid4()}"
+        doc_name = os.path.basename(pdf_path)
+        with self._Session() as session:
+            doc = Document(
+                id=str(uuid.uuid4()),
+                doc_id=doc_id,
+                doc_name=doc_name,
+                tree_json=json.dumps(tree_json),
+                pdf_path=pdf_path,
+            )
+            session.add(doc)
+            session.commit()
+        return doc_id
+
+    def get(self, doc_id: str) -> dict | None:
+        """Return document dict or None if not found."""
+        with self._Session() as session:
+            doc = session.query(Document).filter_by(doc_id=doc_id).first()
+            if doc is None:
+                return None
+            return {
+                "doc_id": doc.doc_id,
+                "doc_name": doc.doc_name,
+                "pdf_path": doc.pdf_path,
+                "tree": json.loads(doc.tree_json),
+                "created_at": doc.created_at,
+            }
+
+    def list(self) -> list[dict]:
+        """Return summary list of all documents (no tree_json)."""
+        with self._Session() as session:
+            docs = session.query(Document).all()
+            return [
+                {
+                    "doc_id": d.doc_id,
+                    "doc_name": d.doc_name,
+                    "created_at": d.created_at,
+                }
+                for d in docs
+            ]
+
+    def delete(self, doc_id: str) -> bool:
+        """Delete a document. Returns True if deleted, False if not found."""
+        with self._Session() as session:
+            doc = session.query(Document).filter_by(doc_id=doc_id).first()
+            if doc is None:
+                return False
+            session.delete(doc)
+            session.commit()
+            return True

--- a/pageindex_rag/storage/models.py
+++ b/pageindex_rag/storage/models.py
@@ -1,0 +1,22 @@
+"""SQLAlchemy models for document storage."""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, String, Text
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    doc_id = Column(String(50), unique=True, nullable=False, index=True)
+    doc_name = Column(String(255), nullable=False)
+    tree_json = Column(Text, nullable=False)
+    pdf_path = Column(Text, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,124 @@
+"""Tests for DocumentStore - document CRUD operations."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from pageindex_rag.storage.models import Base, Document
+from pageindex_rag.storage.document_store import DocumentStore
+
+
+@pytest.fixture
+def engine():
+    """In-memory SQLite engine for tests."""
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    yield eng
+    Base.metadata.drop_all(eng)
+
+
+@pytest.fixture
+def store(engine):
+    """DocumentStore backed by in-memory SQLite."""
+    Session = sessionmaker(bind=engine)
+    return DocumentStore(Session)
+
+
+@pytest.fixture
+def sample_tree():
+    return {
+        "title": "Annual Report 2023",
+        "node_id": "0000",
+        "start_index": 1,
+        "end_index": 50,
+        "nodes": [
+            {"title": "Chapter 1", "node_id": "0001", "start_index": 1, "end_index": 25},
+            {"title": "Chapter 2", "node_id": "0002", "start_index": 26, "end_index": 50},
+        ],
+    }
+
+
+class TestCreateDocument:
+    def test_create_returns_doc_id_with_pi_prefix(self, store, sample_tree):
+        doc_id = store.create("report.pdf", sample_tree)
+        assert doc_id.startswith("pi-")
+
+    def test_create_doc_id_is_unique(self, store, sample_tree):
+        id1 = store.create("report.pdf", sample_tree)
+        id2 = store.create("report.pdf", sample_tree)
+        assert id1 != id2
+
+    def test_create_stores_tree_json(self, store, sample_tree):
+        doc_id = store.create("report.pdf", sample_tree)
+        doc = store.get(doc_id)
+        assert doc["tree"]["title"] == "Annual Report 2023"
+        assert len(doc["tree"]["nodes"]) == 2
+
+    def test_create_stores_pdf_path(self, store, sample_tree):
+        doc_id = store.create("/data/report.pdf", sample_tree)
+        doc = store.get(doc_id)
+        assert doc["pdf_path"] == "/data/report.pdf"
+
+    def test_create_stores_doc_name_from_filename(self, store, sample_tree):
+        doc_id = store.create("/data/annual_report.pdf", sample_tree)
+        doc = store.get(doc_id)
+        assert doc["doc_name"] == "annual_report.pdf"
+
+
+class TestGetDocument:
+    def test_get_returns_none_for_missing_doc_id(self, store):
+        result = store.get("pi-nonexistent")
+        assert result is None
+
+    def test_get_returns_doc_id(self, store, sample_tree):
+        doc_id = store.create("report.pdf", sample_tree)
+        doc = store.get(doc_id)
+        assert doc["doc_id"] == doc_id
+
+    def test_get_returns_created_at(self, store, sample_tree):
+        doc_id = store.create("report.pdf", sample_tree)
+        doc = store.get(doc_id)
+        assert doc["created_at"] is not None
+
+
+class TestListDocuments:
+    def test_list_returns_empty_when_no_documents(self, store):
+        assert store.list() == []
+
+    def test_list_returns_all_documents(self, store, sample_tree):
+        store.create("report1.pdf", sample_tree)
+        store.create("report2.pdf", sample_tree)
+        docs = store.list()
+        assert len(docs) == 2
+
+    def test_list_returns_doc_ids_and_names(self, store, sample_tree):
+        store.create("report.pdf", sample_tree)
+        docs = store.list()
+        assert "doc_id" in docs[0]
+        assert "doc_name" in docs[0]
+        assert "created_at" in docs[0]
+
+    def test_list_does_not_return_tree_json(self, store, sample_tree):
+        store.create("report.pdf", sample_tree)
+        docs = store.list()
+        assert "tree" not in docs[0]
+
+
+class TestDeleteDocument:
+    def test_delete_existing_document_returns_true(self, store, sample_tree):
+        doc_id = store.create("report.pdf", sample_tree)
+        assert store.delete(doc_id) is True
+
+    def test_delete_removes_document(self, store, sample_tree):
+        doc_id = store.create("report.pdf", sample_tree)
+        store.delete(doc_id)
+        assert store.get(doc_id) is None
+
+    def test_delete_nonexistent_returns_false(self, store):
+        assert store.delete("pi-nonexistent") is False
+
+    def test_delete_only_removes_target_document(self, store, sample_tree):
+        id1 = store.create("report1.pdf", sample_tree)
+        id2 = store.create("report2.pdf", sample_tree)
+        store.delete(id1)
+        assert store.get(id2) is not None


### PR DESCRIPTION
## Summary

- 新增 `pageindex_rag/storage/models.py`：SQLAlchemy `Document` 模型，对应 `documents` 表（id, doc_id, doc_name, tree_json, pdf_path, created_at）
- 新增 `pageindex_rag/storage/document_store.py`：`DocumentStore` 类，提供 `create / get / list / delete` 四个 CRUD 方法
- `doc_id` 格式为 `pi-<uuid4>`
- 新增 `tests/test_storage.py`：16 个测试，覆盖所有 CRUD 场景，使用 in-memory SQLite（无需真实 DB）

## Test plan

- [x] `test_create_returns_doc_id_with_pi_prefix`
- [x] `test_create_doc_id_is_unique`
- [x] `test_create_stores_tree_json`
- [x] `test_create_stores_pdf_path`
- [x] `test_create_stores_doc_name_from_filename`
- [x] `test_get_returns_none_for_missing_doc_id`
- [x] `test_get_returns_doc_id`
- [x] `test_get_returns_created_at`
- [x] `test_list_returns_empty_when_no_documents`
- [x] `test_list_returns_all_documents`
- [x] `test_list_returns_doc_ids_and_names`
- [x] `test_list_does_not_return_tree_json`
- [x] `test_delete_existing_document_returns_true`
- [x] `test_delete_removes_document`
- [x] `test_delete_nonexistent_returns_false`
- [x] `test_delete_only_removes_target_document`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)