### PR TITLE
feat: implement NodeContentExtractor (Issue #4)

### DIFF
--- a/pageindex_rag/retrieval/node_extractor.py
+++ b/pageindex_rag/retrieval/node_extractor.py
@@ -1,0 +1,43 @@
+"""NodeContentExtractor: doc_id + node_id[] -> text[]"""
+
+from pageindex.utils import get_nodes, get_page_tokens
+
+
+class NodeContentExtractor:
+    """Extract PDF text for given node_ids from a stored document."""
+
+    def __init__(self, document_store):
+        self._store = document_store
+
+    def extract(self, doc_id: str, node_ids: list[str]) -> dict[str, str]:
+        """Return {node_id: text} for each requested node_id.
+
+        Raises:
+            ValueError: if doc_id not found in store.
+            KeyError: if a node_id is not present in the document tree.
+        """
+        doc = self._store.get(doc_id)
+        if doc is None:
+            raise ValueError(f"doc_id '{doc_id}' not found")
+
+        # Build node_id -> node map from tree
+        all_nodes = get_nodes(doc["tree"])
+        node_map = {n["node_id"]: n for n in all_nodes}
+
+        # Validate all requested node_ids exist
+        for nid in node_ids:
+            if nid not in node_map:
+                raise KeyError(nid)
+
+        # Load PDF pages once
+        pdf_pages = get_page_tokens(doc["pdf_path"])
+
+        results = {}
+        for nid in node_ids:
+            node = node_map[nid]
+            start = node["start_index"]
+            end = node["end_index"]
+            text = "".join(page_text for page_text, _ in pdf_pages[start - 1:end])
+            results[nid] = text
+
+        return results

--- a/tests/test_node_extractor.py
+++ b/tests/test_node_extractor.py
@@ -1,0 +1,120 @@
+"""Tests for NodeContentExtractor (Issue #4)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pageindex_rag.retrieval.node_extractor import NodeContentExtractor
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+TREE = {
+    "title": "Root",
+    "node_id": "0000",
+    "start_index": 1,
+    "end_index": 10,
+    "nodes": [
+        {
+            "title": "Chapter 1",
+            "node_id": "0001",
+            "start_index": 1,
+            "end_index": 4,
+            "nodes": [],
+        },
+        {
+            "title": "Chapter 2",
+            "node_id": "0002",
+            "start_index": 5,
+            "end_index": 10,
+            "nodes": [],
+        },
+    ],
+}
+
+DOC_ID = "pi-test-doc-001"
+
+PDF_PAGES = [(f"page {i} content", i * 100) for i in range(1, 11)]  # 10 pages
+
+
+def _make_store(tree=TREE, pdf_path="/fake/doc.pdf"):
+    """Return a mock DocumentStore that returns the given document."""
+    store = MagicMock()
+    store.get.return_value = {
+        "doc_id": DOC_ID,
+        "pdf_path": pdf_path,
+        "tree": tree,
+    }
+    return store
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestExtractSingleNode:
+    """test_extract_single_node: extract text for one node_id."""
+
+    @patch("pageindex_rag.retrieval.node_extractor.get_page_tokens")
+    def test_extract_single_node(self, mock_get_page_tokens):
+        mock_get_page_tokens.return_value = PDF_PAGES
+
+        store = _make_store()
+        extractor = NodeContentExtractor(store)
+
+        results = extractor.extract(DOC_ID, ["0001"])
+
+        assert len(results) == 1
+        assert "0001" in results
+        # node 0001 covers pages 1-4
+        expected = "".join(p for p, _ in PDF_PAGES[0:4])
+        assert results["0001"] == expected
+
+        store.get.assert_called_once_with(DOC_ID)
+        mock_get_page_tokens.assert_called_once_with("/fake/doc.pdf")
+
+
+class TestExtractMultipleNodes:
+    """test_extract_multiple_nodes: extract text for multiple node_ids."""
+
+    @patch("pageindex_rag.retrieval.node_extractor.get_page_tokens")
+    def test_extract_multiple_nodes(self, mock_get_page_tokens):
+        mock_get_page_tokens.return_value = PDF_PAGES
+
+        store = _make_store()
+        extractor = NodeContentExtractor(store)
+
+        results = extractor.extract(DOC_ID, ["0001", "0002"])
+
+        assert len(results) == 2
+
+        expected_0001 = "".join(p for p, _ in PDF_PAGES[0:4])
+        expected_0002 = "".join(p for p, _ in PDF_PAGES[4:10])
+
+        assert results["0001"] == expected_0001
+        assert results["0002"] == expected_0002
+
+        # PDF should only be read once even for multiple nodes
+        mock_get_page_tokens.assert_called_once()
+
+
+class TestNodeNotFound:
+    """test_node_not_found: missing node_id raises KeyError or returns empty."""
+
+    @patch("pageindex_rag.retrieval.node_extractor.get_page_tokens")
+    def test_node_not_found_raises(self, mock_get_page_tokens):
+        mock_get_page_tokens.return_value = PDF_PAGES
+
+        store = _make_store()
+        extractor = NodeContentExtractor(store)
+
+        with pytest.raises(KeyError):
+            extractor.extract(DOC_ID, ["9999"])
+
+    def test_doc_not_found_raises(self):
+        store = MagicMock()
+        store.get.return_value = None
+
+        extractor = NodeContentExtractor(store)
+
+        with pytest.raises(ValueError, match="doc_id"):
+            extractor.extract("pi-nonexistent", ["0001"])


### PR DESCRIPTION
## Summary

- 新增 `pageindex_rag/retrieval/node_extractor.py`：`NodeContentExtractor` 类
- 复用 `pageindex/utils.py` 中的 `get_nodes`、`get_page_tokens`
- 支持按 `start_index`/`end_index` 从 PDF 提取原文
- doc_id 不存在抛 `ValueError`，node_id 不存在抛 `KeyError`
- PDF 文件仅读取一次，多节点提取效率优化

## Test plan

- [x] `test_extract_single_node` - 单节点提取文本正确
- [x] `test_extract_multiple_nodes` - 多节点批量提取，PDF 只读一次
- [x] `test_node_not_found_raises` - 不存在的 node_id 抛 KeyError
- [x] `test_doc_not_found_raises` - 不存在的 doc_id 抛 ValueError
- [x] 全量测试 44/44 通过

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)