### PR TITLE
feat: implement DescriptionSearcher (Issue #6)

### DIFF
--- a/pageindex_rag/search/description_search.py
+++ b/pageindex_rag/search/description_search.py
@@ -1,0 +1,58 @@
+"""DescriptionSearcher: uses LLM to match query against document descriptions."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from pageindex.utils import ChatGPT_API_async, extract_json
+
+_PROMPT_TEMPLATE = """\
+You are given a list of documents with their IDs, file names, and descriptions.
+Your task is to select documents that may contain information relevant to answering the user query.
+
+Query: {query}
+
+Documents: {documents}
+
+Response Format:
+{{
+    "thinking": "<reasoning>",
+    "answer": ["doc_id1", "doc_id2"]
+}}
+Note: return an empty list [] if no document matches.
+"""
+
+
+class DescriptionSearcher:
+    """Searches documents by matching query against LLM-generated descriptions."""
+
+    def __init__(self, document_store, config: SimpleNamespace):
+        self._store = document_store
+        self._config = config
+
+    async def search(self, query: str) -> list[str]:
+        """Return list of doc_ids whose descriptions match the query."""
+        docs = self._store.query_by_metadata()
+        doc_list = [
+            {
+                "doc_id": d["doc_id"],
+                "doc_name": d["doc_name"],
+                "doc_description": d.get("doc_description") or "",
+            }
+            for d in docs
+        ]
+
+        prompt = _PROMPT_TEMPLATE.format(
+            query=query,
+            documents=json.dumps(doc_list, ensure_ascii=False),
+        )
+
+        response = await ChatGPT_API_async(
+            self._config.model,
+            prompt,
+            self._config.openai_api_key,
+        )
+
+        parsed = extract_json(response)
+        return parsed.get("answer", [])

--- a/tests/test_description_search.py
+++ b/tests/test_description_search.py
@@ -1,0 +1,114 @@
+"""Tests for DescriptionSearcher (Issue #6)."""
+
+import json
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pageindex_rag.search.description_search import DescriptionSearcher
+
+
+@pytest.fixture
+def config():
+    return SimpleNamespace(model="gpt-4o-2024-11-20", openai_api_key="test-key")
+
+
+@pytest.fixture
+def sample_docs():
+    return [
+        {
+            "doc_id": "pi-001",
+            "doc_name": "apple_10k_2023.pdf",
+            "doc_description": "Apple Inc. annual report for fiscal year 2023",
+            "company": "Apple",
+            "fiscal_year": "2023",
+            "filing_type": "10-K",
+        },
+        {
+            "doc_id": "pi-002",
+            "doc_name": "microsoft_10q_2023.pdf",
+            "doc_description": "Microsoft quarterly report for Q3 2023",
+            "company": "Microsoft",
+            "fiscal_year": "2023",
+            "filing_type": "10-Q",
+        },
+        {
+            "doc_id": "pi-003",
+            "doc_name": "tesla_10k_2022.pdf",
+            "doc_description": "Tesla annual report for fiscal year 2022",
+            "company": "Tesla",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+        },
+    ]
+
+
+@pytest.fixture
+def document_store(sample_docs):
+    store = MagicMock()
+    store.query_by_metadata.return_value = sample_docs
+    return store
+
+
+@pytest.mark.asyncio
+async def test_description_search(document_store, config, sample_docs):
+    """Basic match: LLM returns one doc_id, verify it is returned."""
+    llm_response = json.dumps({
+        "thinking": "The query is about Apple financials, doc pi-001 matches.",
+        "answer": ["pi-001"]
+    })
+
+    with patch(
+        "pageindex_rag.search.description_search.ChatGPT_API_async",
+        new=AsyncMock(return_value=llm_response),
+    ), patch(
+        "pageindex_rag.search.description_search.extract_json",
+        return_value={"thinking": "...", "answer": ["pi-001"]},
+    ):
+        searcher = DescriptionSearcher(document_store, config)
+        result = await searcher.search("What is Apple's revenue in 2023?")
+
+    assert result == ["pi-001"]
+    document_store.query_by_metadata.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_no_match(document_store, config):
+    """No match: LLM returns empty answer, result should be empty list."""
+    llm_response = json.dumps({
+        "thinking": "No document matches this query.",
+        "answer": []
+    })
+
+    with patch(
+        "pageindex_rag.search.description_search.ChatGPT_API_async",
+        new=AsyncMock(return_value=llm_response),
+    ), patch(
+        "pageindex_rag.search.description_search.extract_json",
+        return_value={"thinking": "No match", "answer": []},
+    ):
+        searcher = DescriptionSearcher(document_store, config)
+        result = await searcher.search("What is the weather today?")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_match(document_store, config):
+    """Multiple matches: LLM returns multiple doc_ids, all should be returned."""
+    llm_response = json.dumps({
+        "thinking": "Both Apple and Microsoft reports are relevant.",
+        "answer": ["pi-001", "pi-002"]
+    })
+
+    with patch(
+        "pageindex_rag.search.description_search.ChatGPT_API_async",
+        new=AsyncMock(return_value=llm_response),
+    ), patch(
+        "pageindex_rag.search.description_search.extract_json",
+        return_value={"thinking": "...", "answer": ["pi-001", "pi-002"]},
+    ):
+        searcher = DescriptionSearcher(document_store, config)
+        result = await searcher.search("Compare revenue of Apple and Microsoft in 2023?")
+
+    assert result == ["pi-001", "pi-002"]


### PR DESCRIPTION
## Summary
- Implement `DescriptionSearcher` class in `pageindex_rag/search/description_search.py`
- Uses LLM to match query against document descriptions
- Calls `DocumentStore.query_by_metadata()` to get all document metadata (includes `doc_description`)
- Returns list of matching doc_ids

## Test plan
- [x] `test_description_search` — basic match returns correct doc_ids
- [x] `test_no_match` — no match returns empty list
- [x] `test_multiple_match` — multiple matches returned correctly

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)