### PR TITLE
feat: implement DocumentSearchRouter (Issue #9)

### DIFF
--- a/pageindex_rag/search/router.py
+++ b/pageindex_rag/search/router.py
@@ -1,0 +1,110 @@
+"""DocumentSearchRouter: routes search queries to appropriate searcher strategies."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+
+
+class DocumentSearchRouter:
+    """Routes document search queries across description, metadata, and semantic searchers.
+
+    Strategies:
+        - "description": use DescriptionSearcher only
+        - "metadata": use MetadataSearcher only
+        - "semantic": use SemanticSearcher only
+        - "combined": merge results from all available searchers, ranked by hit frequency
+    """
+
+    def __init__(
+        self,
+        description_searcher=None,
+        metadata_searcher=None,
+        semantic_searcher=None,
+        strategy: str = "combined",
+    ):
+        self._description_searcher = description_searcher
+        self._metadata_searcher = metadata_searcher
+        self._semantic_searcher = semantic_searcher
+        self._strategy = strategy
+
+    async def search(self, query: str) -> list[str]:
+        """Search documents using the configured strategy.
+
+        Args:
+            query: The user query string.
+
+        Returns:
+            List of doc_ids matching the query.
+        """
+        strategy = self._strategy
+
+        if strategy == "description":
+            if self._description_searcher is None:
+                return []
+            return await self._description_searcher.search(query)
+
+        elif strategy == "metadata":
+            if self._metadata_searcher is None:
+                return []
+            return await self._metadata_searcher.search(query)
+
+        elif strategy == "semantic":
+            if self._semantic_searcher is None:
+                return []
+            return self._semantic_searcher.search(query)
+
+        elif strategy == "combined":
+            return await self._combined_search(query)
+
+        else:
+            raise ValueError(f"Unknown strategy: {strategy!r}")
+
+    async def _combined_search(self, query: str) -> list[str]:
+        """Run all available searchers and merge results by hit frequency."""
+        all_results: list[list[str]] = []
+
+        # Gather async searchers concurrently
+        async_tasks = []
+        async_indices = []
+
+        if self._description_searcher is not None:
+            async_tasks.append(self._description_searcher.search(query))
+            async_indices.append(len(all_results))
+            all_results.append([])  # placeholder
+
+        if self._metadata_searcher is not None:
+            async_tasks.append(self._metadata_searcher.search(query))
+            async_indices.append(len(all_results))
+            all_results.append([])  # placeholder
+
+        if async_tasks:
+            gathered = await asyncio.gather(*async_tasks)
+            for idx, result in zip(async_indices, gathered):
+                all_results[idx] = result
+
+        # Synchronous semantic searcher
+        if self._semantic_searcher is not None:
+            semantic_result = self._semantic_searcher.search(query)
+            all_results.append(semantic_result)
+
+        # Merge: count occurrences, preserve first-seen order for ties
+        counter: Counter = Counter()
+        first_seen_order: list[str] = []
+        seen: set[str] = set()
+
+        for result_list in all_results:
+            for doc_id in result_list:
+                counter[doc_id] += 1
+                if doc_id not in seen:
+                    first_seen_order.append(doc_id)
+                    seen.add(doc_id)
+
+        # Sort by count descending, ties broken by first-seen order
+        first_seen_index = {doc_id: i for i, doc_id in enumerate(first_seen_order)}
+        ranked = sorted(
+            first_seen_order,
+            key=lambda d: (-counter[d], first_seen_index[d]),
+        )
+
+        return ranked

--- a/tests/test_search_router.py
+++ b/tests/test_search_router.py
@@ -1,0 +1,94 @@
+"""Tests for DocumentSearchRouter (Issue #9)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from pageindex_rag.search.router import DocumentSearchRouter
+
+
+@pytest.mark.asyncio
+async def test_route_to_metadata():
+    """strategy='metadata' 只调用 metadata_searcher，其他搜索器不被调用。"""
+    description_searcher = MagicMock()
+    description_searcher.search = AsyncMock()
+
+    metadata_searcher = MagicMock()
+    metadata_searcher.search = AsyncMock(return_value=["pi-001"])
+
+    semantic_searcher = MagicMock()
+    semantic_searcher.search = MagicMock()
+
+    router = DocumentSearchRouter(
+        description_searcher=description_searcher,
+        metadata_searcher=metadata_searcher,
+        semantic_searcher=semantic_searcher,
+        strategy="metadata",
+    )
+
+    result = await router.search("Apple 2023 10-K")
+
+    metadata_searcher.search.assert_called_once_with("Apple 2023 10-K")
+    description_searcher.search.assert_not_called()
+    semantic_searcher.search.assert_not_called()
+    assert result == ["pi-001"]
+
+
+@pytest.mark.asyncio
+async def test_route_to_description():
+    """strategy='description' 只调用 description_searcher，其他搜索器不被调用。"""
+    description_searcher = MagicMock()
+    description_searcher.search = AsyncMock(return_value=["pi-002"])
+
+    metadata_searcher = MagicMock()
+    metadata_searcher.search = AsyncMock()
+
+    semantic_searcher = MagicMock()
+    semantic_searcher.search = MagicMock()
+
+    router = DocumentSearchRouter(
+        description_searcher=description_searcher,
+        metadata_searcher=metadata_searcher,
+        semantic_searcher=semantic_searcher,
+        strategy="description",
+    )
+
+    result = await router.search("annual report financial highlights")
+
+    description_searcher.search.assert_called_once_with("annual report financial highlights")
+    metadata_searcher.search.assert_not_called()
+    semantic_searcher.search.assert_not_called()
+    assert result == ["pi-002"]
+
+
+@pytest.mark.asyncio
+async def test_combined_results():
+    """strategy='combined' 合并三个搜索器结果，按出现次数降序排列。"""
+    description_searcher = MagicMock()
+    description_searcher.search = AsyncMock(return_value=["pi-001", "pi-002"])
+
+    metadata_searcher = MagicMock()
+    metadata_searcher.search = AsyncMock(return_value=["pi-002", "pi-003"])
+
+    semantic_searcher = MagicMock()
+    semantic_searcher.search = MagicMock(return_value=["pi-001", "pi-003"])
+
+    router = DocumentSearchRouter(
+        description_searcher=description_searcher,
+        metadata_searcher=metadata_searcher,
+        semantic_searcher=semantic_searcher,
+        strategy="combined",
+    )
+
+    result = await router.search("revenue growth analysis")
+
+    # pi-001: description + semantic = 2次
+    # pi-002: description + metadata = 2次
+    # pi-003: metadata + semantic = 2次
+    # 三者出现次数相同，按首次出现顺序排列
+    assert len(result) == 3
+    # 出现2次的都在前面
+    assert set(result) == {"pi-001", "pi-002", "pi-003"}
+    # 按首次出现顺序：pi-001 首次出现于 description[0]，pi-002 首次出现于 description[1]，pi-003 首次出现于 metadata[1]
+    assert result[0] == "pi-001"
+    assert result[1] == "pi-002"
+    assert result[2] == "pi-003"


### PR DESCRIPTION
## Summary
- Implement `DocumentSearchRouter` in `pageindex_rag/search/router.py`
- Supports four strategies: `description`, `metadata`, `semantic`, `combined`
- Combined mode merges results from all searchers, ranked by hit frequency
- Gracefully handles missing searchers (returns empty list)

## Test plan
- [x] `test_route_to_metadata` — only metadata searcher called
- [x] `test_route_to_description` — only description searcher called
- [x] `test_combined_results` — merged and frequency-ranked results

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)