### PR TITLE
feat: implement RAGPipeline for Issue #10

### DIFF
--- a/pageindex_rag/pipeline/answer_generator.py
+++ b/pageindex_rag/pipeline/answer_generator.py
@@ -1,0 +1,38 @@
+from pageindex_rag.config import get_config
+from pageindex.utils import ChatGPT_API_async
+
+
+class AnswerGenerator:
+    def __init__(self, config=None):
+        self.config = config or get_config()
+
+    async def generate(self, query: str, nodes_content: list) -> str:
+        """
+        基于检索到的节点内容生成答案。
+        复用 pageindex/utils.py 中的 ChatGPT_API_async。
+        """
+
+        # 构建上下文
+        context_parts = []
+        for node in nodes_content:
+            content = node.get("content", "")
+            node_id = node.get("node_id", "")
+            page_range = node.get("page_range", "")
+            context_parts.append(f"[节点 {node_id}, 页码 {page_range}]\n{content}")
+
+        context = "\n\n".join(context_parts)
+
+        prompt = f"""请根据以下文档内容回答问题。
+
+文档内容：
+{context}
+
+问题：{query}
+
+请基于文档内容给出准确、详细的回答。如果文档内容不足以回答问题，请说明。"""
+
+        messages = [{"role": "user", "content": prompt}]
+
+        model = getattr(self.config, "model", "gpt-4o-mini")
+        answer = await ChatGPT_API_async(messages, model=model)
+        return answer

--- a/pageindex_rag/pipeline/rag_pipeline.py
+++ b/pageindex_rag/pipeline/rag_pipeline.py
@@ -1,0 +1,89 @@
+import asyncio
+from typing import Optional
+
+
+class RAGPipeline:
+    def __init__(self, document_store, tree_searcher, node_extractor,
+                 search_router=None, config=None):
+        self.document_store = document_store
+        self.tree_searcher = tree_searcher
+        self.node_extractor = node_extractor
+        self.search_router = search_router
+        self.config = config
+
+    async def query(self, query: str, doc_id: str = None) -> dict:
+        """
+        执行 RAG 查询。
+        - 单文档（doc_id 指定）：TreeSearcher.search() → NodeContentExtractor.extract() → 答案生成
+        - 多文档（doc_id=None）：SearchRouter.search() → 对每个 doc_id 做树搜索 → 汇总节点 → 答案生成
+        返回: {"answer": str, "sources": list[{"doc_id", "node_id", "page_range"}]}
+        """
+        from pageindex_rag.pipeline.answer_generator import AnswerGenerator
+
+        answer_generator = AnswerGenerator(config=self.config)
+
+        if doc_id is not None:
+            # 单文档模式
+            doc = self.document_store.get(doc_id)
+            if doc is None:
+                return {"answer": "未找到指定文档。", "sources": []}
+
+            tree = doc.get("tree_json") or doc.get("tree")
+            node_ids = await self.tree_searcher.search(query, tree)
+
+            if not node_ids:
+                return {"answer": "在文档中未找到相关内容。", "sources": []}
+
+            nodes_content = self.node_extractor.extract(doc_id, node_ids)
+            answer = await answer_generator.generate(query, nodes_content)
+
+            sources = []
+            for node in nodes_content:
+                sources.append({
+                    "doc_id": doc_id,
+                    "node_id": node.get("node_id"),
+                    "page_range": node.get("page_range")
+                })
+
+            return {"answer": answer, "sources": sources}
+
+        else:
+            # 多文档模式
+            if self.search_router is None:
+                return {"answer": "未配置搜索路由器，无法执行多文档查询。", "sources": []}
+
+            search_results = await self.search_router.search(query)
+
+            if not search_results:
+                return {"answer": "未找到与查询相关的文档。", "sources": []}
+
+            all_nodes_content = []
+            all_sources = []
+
+            for result in search_results:
+                result_doc_id = result.get("doc_id")
+                doc = self.document_store.get(result_doc_id)
+                if doc is None:
+                    continue
+
+                tree = doc.get("tree_json") or doc.get("tree")
+                node_ids = await self.tree_searcher.search(query, tree)
+
+                if not node_ids:
+                    continue
+
+                nodes_content = self.node_extractor.extract(result_doc_id, node_ids)
+                all_nodes_content.extend(nodes_content)
+
+                for node in nodes_content:
+                    all_sources.append({
+                        "doc_id": result_doc_id,
+                        "node_id": node.get("node_id"),
+                        "page_range": node.get("page_range")
+                    })
+
+            if not all_nodes_content:
+                return {"answer": "在相关文档中未找到具体内容。", "sources": []}
+
+            answer = await answer_generator.generate(query, all_nodes_content)
+            return {"answer": answer, "sources": all_sources}

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_document_store():
+    store = MagicMock()
+    store.get.return_value = {
+        "doc_id": "pi-test-123",
+        "tree_json": {
+            "title": "Test Document",
+            "node_id": "0001",
+            "start_index": 1,
+            "end_index": 10,
+            "nodes": []
+        }
+    }
+    return store
+
+
+@pytest.fixture
+def mock_tree_searcher():
+    searcher = MagicMock()
+    searcher.search = AsyncMock(return_value=["0001", "0002"])
+    return searcher
+
+
+@pytest.fixture
+def mock_node_extractor():
+    extractor = MagicMock()
+    extractor.extract.return_value = [
+        {"node_id": "0001", "content": "Test content 1", "page_range": "1-5"},
+        {"node_id": "0002", "content": "Test content 2", "page_range": "6-10"}
+    ]
+    return extractor
+
+
+@pytest.fixture
+def mock_search_router():
+    router = MagicMock()
+    router.search = AsyncMock(return_value=[
+        {"doc_id": "pi-test-123", "score": 0.9},
+        {"doc_id": "pi-test-456", "score": 0.8}
+    ])
+    return router
+
+
+@pytest.mark.asyncio
+async def test_single_doc_pipeline(mock_document_store, mock_tree_searcher, mock_node_extractor):
+    """测试单文档模式的 RAG Pipeline"""
+    from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+
+    with patch("pageindex_rag.pipeline.answer_generator.ChatGPT_API_async", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = "这是基于文档内容生成的答案。"
+
+        pipeline = RAGPipeline(
+            document_store=mock_document_store,
+            tree_searcher=mock_tree_searcher,
+            node_extractor=mock_node_extractor
+        )
+
+        result = await pipeline.query("测试问题", doc_id="pi-test-123")
+
+        assert "answer" in result
+        assert "sources" in result
+        assert result["answer"] == "这是基于文档内容生成的答案。"
+        assert len(result["sources"]) == 2
+        assert result["sources"][0]["doc_id"] == "pi-test-123"
+        assert result["sources"][0]["node_id"] == "0001"
+
+        mock_document_store.get.assert_called_once_with("pi-test-123")
+        mock_tree_searcher.search.assert_called_once()
+        mock_node_extractor.extract.assert_called_once_with("pi-test-123", ["0001", "0002"])
+
+
+@pytest.mark.asyncio
+async def test_multi_doc_pipeline(mock_document_store, mock_tree_searcher, mock_node_extractor, mock_search_router):
+    """测试多文档模式的 RAG Pipeline"""
+    from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+
+    # 第二个文档
+    def get_doc(doc_id):
+        docs = {
+            "pi-test-123": {
+                "doc_id": "pi-test-123",
+                "tree_json": {"title": "Doc 1", "node_id": "0001", "start_index": 1, "end_index": 10, "nodes": []}
+            },
+            "pi-test-456": {
+                "doc_id": "pi-test-456",
+                "tree_json": {"title": "Doc 2", "node_id": "0001", "start_index": 1, "end_index": 20, "nodes": []}
+            }
+        }
+        return docs.get(doc_id)
+
+    mock_document_store.get.side_effect = get_doc
+
+    with patch("pageindex_rag.pipeline.answer_generator.ChatGPT_API_async", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = "基于多个文档生成的综合答案。"
+
+        pipeline = RAGPipeline(
+            document_store=mock_document_store,
+            tree_searcher=mock_tree_searcher,
+            node_extractor=mock_node_extractor,
+            search_router=mock_search_router
+        )
+
+        result = await pipeline.query("跨文档问题")
+
+        assert "answer" in result
+        assert "sources" in result
+        assert result["answer"] == "基于多个文档生成的综合答案。"
+        assert len(result["sources"]) == 4  # 2个文档，每个2个节点
+
+        mock_search_router.search.assert_called_once_with("跨文档问题")
+        assert mock_tree_searcher.search.call_count == 2
+        assert mock_node_extractor.extract.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_relevant_doc(mock_document_store, mock_tree_searcher, mock_node_extractor):
+    """测试 SearchRouter 返回空列表的情况"""
+    from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+
+    empty_router = MagicMock()
+    empty_router.search = AsyncMock(return_value=[])
+
+    pipeline = RAGPipeline(
+        document_store=mock_document_store,
+        tree_searcher=mock_tree_searcher,
+        node_extractor=mock_node_extractor,
+        search_router=empty_router
+    )
+
+    result = await pipeline.query("无相关文档的问题")
+
+    assert "answer" in result
+    assert "sources" in result
+    assert result["sources"] == []
+    assert "未找到" in result["answer"] or "no" in result["answer"].lower()


### PR DESCRIPTION
## Summary

- 实现 `RAGPipeline` 类，支持单文档和多文档两种查询模式
- 实现 `AnswerGenerator` 类，复用 `ChatGPT_API_async` 生成答案
- 单文档模式：`TreeSearcher.search()` → `NodeContentExtractor.extract()` → 答案生成
- 多文档模式：`SearchRouter.search()` → 对每个 doc_id 树搜索 → 汇总节点 → 答案生成

## Test plan

- [x] `test_single_doc_pipeline` — mock TreeSearcher + NodeExtractor + LLM
- [x] `test_multi_doc_pipeline` — mock SearchRouter + TreeSearcher + NodeExtractor + LLM
- [x] `test_no_relevant_doc` — SearchRouter 返回空列表，答案提示无相关文档
- [x] 全量测试 64/64 通过，无回归

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)