### PR TITLE
feat: implement DocumentIngestion for Issue #11

### DIFF
--- a/pageindex_rag/ingestion/ingest.py
+++ b/pageindex_rag/ingestion/ingest.py
@@ -1,0 +1,67 @@
+import uuid
+from typing import Optional
+
+from pageindex.page_index import page_index_main
+from pageindex.page_index_md import md_to_tree
+from pageindex.utils import generate_doc_description
+
+
+class DocumentIngestion:
+    def __init__(self, document_store, semantic_searcher, config=None):
+        self.document_store = document_store
+        self.semantic_searcher = semantic_searcher
+        self.config = config
+
+    async def ingest_pdf(self, pdf_path: str, metadata: dict = None) -> str:
+        """
+        入库 PDF 文档。
+        流程：
+        1. page_index_main(pdf_path) → tree_json
+        2. 若 metadata 无 doc_description，调 generate_doc_description(tree) 生成
+        3. DocumentStore.create(path, tree_json, metadata) → doc_id
+        4. SemanticSearcher.index_document(doc_id, tree_json) 建语义索引
+        返回 doc_id
+        """
+        # 1. PDF → tree
+        tree_json = page_index_main(pdf_path)
+
+        # 2. 生成文档描述（如果没有提供）
+        metadata = metadata or {}
+        if not metadata.get("doc_description"):
+            model = getattr(self.config, "model", "gpt-4o-mini") if self.config else "gpt-4o-mini"
+            metadata["doc_description"] = generate_doc_description(tree_json, model)
+
+        # 3. 存储文档
+        doc_id = self.document_store.create(pdf_path, tree_json, metadata)
+
+        # 4. 建语义索引
+        self.semantic_searcher.index_document(doc_id, tree_json)
+
+        return doc_id
+
+    async def ingest_md(self, md_path: str, metadata: dict = None) -> str:
+        """
+        入库 Markdown 文档。
+        流程：
+        1. md_to_tree(md_path) → tree_json
+        2. 若 metadata 无 doc_description，调 generate_doc_description(tree) 生成
+        3. DocumentStore.create(path, tree_json, metadata) → doc_id
+        4. SemanticSearcher.index_document(doc_id, tree_json) 建语义索引
+        返回 doc_id
+        """
+        # 1. MD → tree（md_to_tree 是 async）
+        tree_json = await md_to_tree(md_path)
+
+        # 2. 生成文档描述（如果没有提供）
+        metadata = metadata or {}
+        if not metadata.get("doc_description"):
+            model = getattr(self.config, "model", "gpt-4o-mini") if self.config else "gpt-4o-mini"
+            metadata["doc_description"] = generate_doc_description(tree_json, model)
+
+        # 3. 存储文档
+        doc_id = self.document_store.create(md_path, tree_json, metadata)
+
+        # 4. 建语义索引
+        self.semantic_searcher.index_document(doc_id, tree_json)
+
+        return doc_id

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,129 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+SAMPLE_TREE = {
+    "title": "Test Document",
+    "node_id": "0001",
+    "start_index": 1,
+    "end_index": 10,
+    "nodes": [
+        {
+            "title": "Chapter 1",
+            "node_id": "0002",
+            "start_index": 1,
+            "end_index": 5,
+            "nodes": []
+        }
+    ]
+}
+
+
+@pytest.fixture
+def mock_document_store():
+    store = MagicMock()
+    store.create.return_value = "pi-test-550e8400"
+    return store
+
+
+@pytest.fixture
+def mock_semantic_searcher():
+    searcher = MagicMock()
+    searcher.index_document.return_value = None
+    return searcher
+
+
+@pytest.mark.asyncio
+async def test_ingest_pdf(mock_document_store, mock_semantic_searcher):
+    """测试 PDF 文档入库流程"""
+    from pageindex_rag.ingestion.ingest import DocumentIngestion
+
+    with patch("pageindex_rag.ingestion.ingest.page_index_main") as mock_page_index, \
+         patch("pageindex_rag.ingestion.ingest.generate_doc_description") as mock_gen_desc:
+
+        mock_page_index.return_value = SAMPLE_TREE
+        mock_gen_desc.return_value = "这是一份测试PDF文档的描述。"
+
+        ingestion = DocumentIngestion(
+            document_store=mock_document_store,
+            semantic_searcher=mock_semantic_searcher
+        )
+
+        doc_id = await ingestion.ingest_pdf("/path/to/test.pdf")
+
+        assert doc_id == "pi-test-550e8400"
+        mock_page_index.assert_called_once_with("/path/to/test.pdf")
+        mock_gen_desc.assert_called_once()
+        mock_document_store.create.assert_called_once_with(
+            "/path/to/test.pdf",
+            SAMPLE_TREE,
+            {"doc_description": "这是一份测试PDF文档的描述。"}
+        )
+        mock_semantic_searcher.index_document.assert_called_once_with(
+            "pi-test-550e8400", SAMPLE_TREE
+        )
+
+
+@pytest.mark.asyncio
+async def test_ingest_md(mock_document_store, mock_semantic_searcher):
+    """测试 Markdown 文档入库流程"""
+    from pageindex_rag.ingestion.ingest import DocumentIngestion
+
+    with patch("pageindex_rag.ingestion.ingest.md_to_tree", new_callable=AsyncMock) as mock_md_tree, \
+         patch("pageindex_rag.ingestion.ingest.generate_doc_description") as mock_gen_desc:
+
+        mock_md_tree.return_value = SAMPLE_TREE
+        mock_gen_desc.return_value = "这是一份测试Markdown文档的描述。"
+
+        ingestion = DocumentIngestion(
+            document_store=mock_document_store,
+            semantic_searcher=mock_semantic_searcher
+        )
+
+        doc_id = await ingestion.ingest_md("/path/to/test.md")
+
+        assert doc_id == "pi-test-550e8400"
+        mock_md_tree.assert_called_once_with("/path/to/test.md")
+        mock_gen_desc.assert_called_once()
+        mock_document_store.create.assert_called_once_with(
+            "/path/to/test.md",
+            SAMPLE_TREE,
+            {"doc_description": "这是一份测试Markdown文档的描述。"}
+        )
+        mock_semantic_searcher.index_document.assert_called_once_with(
+            "pi-test-550e8400", SAMPLE_TREE
+        )
+
+
+@pytest.mark.asyncio
+async def test_ingest_with_metadata(mock_document_store, mock_semantic_searcher):
+    """测试提供完整 metadata 时不调用 generate_doc_description"""
+    from pageindex_rag.ingestion.ingest import DocumentIngestion
+
+    full_metadata = {
+        "doc_description": "已提供的文档描述",
+        "company": "Test Corp",
+        "fiscal_year": "2023",
+        "filing_type": "10-K"
+    }
+
+    with patch("pageindex_rag.ingestion.ingest.page_index_main") as mock_page_index, \
+         patch("pageindex_rag.ingestion.ingest.generate_doc_description") as mock_gen_desc:
+
+        mock_page_index.return_value = SAMPLE_TREE
+
+        ingestion = DocumentIngestion(
+            document_store=mock_document_store,
+            semantic_searcher=mock_semantic_searcher
+        )
+
+        doc_id = await ingestion.ingest_pdf("/path/to/test.pdf", metadata=full_metadata)
+
+        assert doc_id == "pi-test-550e8400"
+        # 不应该调用 generate_doc_description
+        mock_gen_desc.assert_not_called()
+        mock_document_store.create.assert_called_once_with(
+            "/path/to/test.pdf",
+            SAMPLE_TREE,
+            full_metadata
+        )


### PR DESCRIPTION
## Summary

- 实现 `DocumentIngestion` 类，支持 PDF 和 Markdown 文档入库
- PDF 流程：`page_index_main()` → 生成描述 → `DocumentStore.create()` → `SemanticSearcher.index_document()`
- MD 流程：`md_to_tree()` (async) → 生成描述 → `DocumentStore.create()` → `SemanticSearcher.index_document()`
- 提供完整 metadata 时跳过 `generate_doc_description` 调用

## Test plan

- [x] `test_ingest_pdf` — mock page_index_main + DocumentStore + SemanticSearcher
- [x] `test_ingest_md` — mock md_to_tree + DocumentStore + SemanticSearcher
- [x] `test_ingest_with_metadata` — 提供完整 metadata，不调用 generate_doc_description
- [x] 全量测试 64/64 通过，无回归

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)