### PR TITLE
feat: implement FinanceBench evaluation framework for Issue #14

### DIFF
--- a/pageindex_rag/benchmark/evaluator.py
+++ b/pageindex_rag/benchmark/evaluator.py
@@ -1,0 +1,130 @@
+"""FinanceBench evaluator: LLM equivalence judge and benchmark runner."""
+
+import asyncio
+from pageindex_rag.config import get_config
+from pageindex.utils import ChatGPT_API
+
+
+class AnswerEquivalenceJudge:
+    """使用 LLM 判定两个答案是否语义等价。"""
+
+    def __init__(self, config=None):
+        self.config = config or get_config()
+
+    def judge(self, predicted: str, expected: str) -> bool:
+        """
+        LLM 等价性判定，处理：
+        - 数值相似性（$1.5B vs $1,500M）
+        - 单位互换（百万/千万/亿）
+        - 超集判定（预测包含正确答案）
+        返回 True 表示等价，False 表示不等价。
+        """
+        prompt = f"""You are an answer equivalence judge for financial Q&A evaluation.
+
+Determine if the "Predicted Answer" is equivalent to the "Expected Answer".
+
+Rules:
+1. Numeric equivalence: treat values like "$1.5B" and "$1,500M" as equivalent.
+2. Unit conversion: handle million/billion/trillion conversions correctly.
+3. Superset acceptance: if the predicted answer contains the expected answer as a correct subset, consider it equivalent.
+4. Minor wording differences are acceptable as long as the factual content matches.
+
+Expected Answer: {expected}
+Predicted Answer: {predicted}
+
+Respond with exactly one word: YES if equivalent, NO if not equivalent."""
+
+        response = ChatGPT_API(
+            model=self.config.model,
+            prompt=prompt,
+            api_key=self.config.openai_api_key,
+        )
+        return response.strip().upper().startswith("YES")
+
+
+class BenchmarkEvaluator:
+    """对 FinanceBench 数据集运行 RAGPipeline 并评估结果。"""
+
+    def __init__(self, pipeline, dataset, judge=None, config=None):
+        self.pipeline = pipeline
+        self.dataset = dataset
+        self.config = config or get_config()
+        self.judge = judge or AnswerEquivalenceJudge(config=self.config)
+
+    async def evaluate(self, limit: int = None) -> dict:
+        """
+        对 dataset 中每题调用 pipeline.query()，用 judge 判定是否正确。
+        返回评估结果字典。
+        """
+        total = len(self.dataset) if limit is None else min(limit, len(self.dataset))
+        passed = 0
+        failed_cases = []
+
+        for idx in range(total):
+            item = self.dataset[idx]
+            question = item["question"]
+            expected = item["answer"]
+            doc_name = item.get("doc_name", "")
+
+            # 调用 pipeline 获取答案
+            try:
+                result = await self.pipeline.query(question)
+                predicted = result.get("answer", "")
+                doc_id = result.get("sources", [{}])[0].get("doc_id", "") if result.get("sources") else ""
+            except Exception:
+                predicted = ""
+                doc_id = ""
+
+            # 判定等价性
+            is_correct = self.judge.judge(predicted, expected)
+
+            if is_correct:
+                passed += 1
+            else:
+                failed_cases.append({
+                    "question": question,
+                    "expected": expected,
+                    "predicted": predicted,
+                    "doc_id": doc_id,
+                })
+
+        accuracy = passed / total if total > 0 else 0.0
+
+        return {
+            "accuracy": accuracy,
+            "total": total,
+            "passed": passed,
+            "failed_cases": failed_cases,
+        }
+
+    def generate_report(self, results: dict) -> str:
+        """生成可读的评估报告文本。"""
+        accuracy = results["accuracy"]
+        total = results["total"]
+        passed = results["passed"]
+        failed = total - passed
+        failed_cases = results.get("failed_cases", [])
+
+        lines = [
+            "=" * 60,
+            "FinanceBench Evaluation Report",
+            "=" * 60,
+            f"Accuracy:  {accuracy:.2%}  ({passed}/{total})",
+            f"Passed:    {passed}",
+            f"Failed:    {failed}",
+            "=" * 60,
+        ]
+
+        if failed_cases:
+            lines.append(f"\nFailed Cases ({len(failed_cases)}):")
+            for i, case in enumerate(failed_cases[:10], 1):  # 最多显示前10条
+                lines.append(f"\n[{i}] Question: {case['question'][:100]}")
+                lines.append(f"    Expected:  {case['expected'][:100]}")
+                lines.append(f"    Predicted: {case['predicted'][:100]}")
+                if case.get("doc_id"):
+                    lines.append(f"    Doc ID:    {case['doc_id']}")
+            if len(failed_cases) > 10:
+                lines.append(f"\n... and {len(failed_cases) - 10} more failed cases.")
+
+        lines.append("\n" + "=" * 60)
+        return "\n".join(lines)

--- a/pageindex_rag/benchmark/financebench.py
+++ b/pageindex_rag/benchmark/financebench.py
@@ -1,0 +1,43 @@
+"""FinanceBench dataset loader for PageIndex RAG evaluation."""
+
+from datasets import load_dataset
+
+
+class FinanceBenchDataset:
+    """加载并提供 FinanceBench 数据集访问接口。"""
+
+    def __init__(self, split="train"):
+        """从 HuggingFace 加载 PatronusAI/financebench 数据集。"""
+        ds = load_dataset("PatronusAI/financebench", split=split)
+        self._data = list(ds)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __getitem__(self, idx) -> dict:
+        """返回标准化的题目字典。"""
+        row = self._data[idx]
+        return {
+            "question": row.get("question", ""),
+            "answer": row.get("answer", ""),
+            "company": row.get("company", ""),
+            "fiscal_year": row.get("fiscal_year", ""),
+            "filing_type": row.get("filing_type", ""),
+            "doc_name": row.get("doc_name", ""),
+        }
+
+    def get_unique_docs(self) -> list:
+        """返回需要入库的唯一文档列表（按 doc_name 去重）。"""
+        seen = set()
+        unique = []
+        for item in self._data:
+            doc_name = item.get("doc_name", "")
+            if doc_name and doc_name not in seen:
+                seen.add(doc_name)
+                unique.append({
+                    "doc_name": doc_name,
+                    "company": item.get("company", ""),
+                    "fiscal_year": item.get("fiscal_year", ""),
+                    "filing_type": item.get("filing_type", ""),
+                })
+        return unique

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,179 @@
+"""Tests for FinanceBench evaluation framework."""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+
+def test_load_financebench():
+    """测试 FinanceBenchDataset 能正确解析数据（mock HuggingFace）。"""
+    mock_rows = [
+        {
+            "question": "What was Apple's revenue in 2022?",
+            "answer": "$394.3 billion",
+            "company": "Apple",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+            "doc_name": "APPLE_2022_10K",
+        },
+        {
+            "question": "What was Apple's net income in 2022?",
+            "answer": "$99.8 billion",
+            "company": "Apple",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+            "doc_name": "APPLE_2022_10K",
+        },
+        {
+            "question": "What was Microsoft's revenue in 2022?",
+            "answer": "$198.3 billion",
+            "company": "Microsoft",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+            "doc_name": "MSFT_2022_10K",
+        },
+    ]
+
+    with patch("pageindex_rag.benchmark.financebench.load_dataset") as mock_load:
+        mock_load.return_value = mock_rows
+
+        from pageindex_rag.benchmark.financebench import FinanceBenchDataset
+        ds = FinanceBenchDataset(split="train")
+
+        # 验证加载调用
+        mock_load.assert_called_once_with("PatronusAI/financebench", split="train")
+
+        # 验证长度
+        assert len(ds) == 3
+
+        # 验证 __getitem__
+        item = ds[0]
+        assert item["question"] == "What was Apple's revenue in 2022?"
+        assert item["answer"] == "$394.3 billion"
+        assert item["company"] == "Apple"
+        assert item["fiscal_year"] == "2022"
+        assert item["filing_type"] == "10-K"
+        assert item["doc_name"] == "APPLE_2022_10K"
+
+        # 验证 get_unique_docs（应返回2个唯一文档）
+        unique_docs = ds.get_unique_docs()
+        assert len(unique_docs) == 2
+        doc_names = [d["doc_name"] for d in unique_docs]
+        assert "APPLE_2022_10K" in doc_names
+        assert "MSFT_2022_10K" in doc_names
+
+
+def test_answer_equivalence_judge():
+    """测试 AnswerEquivalenceJudge.judge() 返回正确布尔值（mock ChatGPT_API）。"""
+    with patch("pageindex_rag.benchmark.evaluator.ChatGPT_API") as mock_api:
+        from pageindex_rag.benchmark.evaluator import AnswerEquivalenceJudge
+
+        config = MagicMock()
+        config.model = "gpt-4o-2024-11-20"
+        config.openai_api_key = "test-key"
+
+        judge = AnswerEquivalenceJudge(config=config)
+
+        # 测试等价情况（YES）
+        mock_api.return_value = "YES"
+        result = judge.judge("$1,500M", "$1.5B")
+        assert result is True
+        mock_api.assert_called_once()
+
+        # 测试不等价情况（NO）
+        mock_api.reset_mock()
+        mock_api.return_value = "NO"
+        result = judge.judge("$1.5B", "$2.0B")
+        assert result is False
+        mock_api.assert_called_once()
+
+        # 测试响应中含有额外文字但以 YES 开头
+        mock_api.reset_mock()
+        mock_api.return_value = "YES, they are equivalent."
+        result = judge.judge("394.3 billion", "$394.3 billion")
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_evaluation_report():
+    """测试 BenchmarkEvaluator.evaluate() 和 generate_report() 的输出格式。"""
+    # 构造 mock dataset（3题）
+    mock_items = [
+        {
+            "question": "What was revenue?",
+            "answer": "$100M",
+            "doc_name": "DOC_A",
+            "company": "Corp A",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+        },
+        {
+            "question": "What was net income?",
+            "answer": "$20M",
+            "doc_name": "DOC_A",
+            "company": "Corp A",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+        },
+        {
+            "question": "What was total assets?",
+            "answer": "$500M",
+            "doc_name": "DOC_B",
+            "company": "Corp B",
+            "fiscal_year": "2022",
+            "filing_type": "10-K",
+        },
+    ]
+
+    mock_dataset = MagicMock()
+    mock_dataset.__len__ = MagicMock(return_value=3)
+    mock_dataset.__getitem__ = MagicMock(side_effect=lambda idx: mock_items[idx])
+
+    # mock pipeline：前两题答对，第三题答错
+    async def mock_query(question, doc_id=None):
+        if "revenue" in question:
+            return {"answer": "$100M", "sources": [{"doc_id": "pi-doc-a", "node_id": "0001"}]}
+        elif "net income" in question:
+            return {"answer": "$20M", "sources": [{"doc_id": "pi-doc-a", "node_id": "0002"}]}
+        else:
+            return {"answer": "$300M", "sources": [{"doc_id": "pi-doc-b", "node_id": "0001"}]}
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.query = AsyncMock(side_effect=mock_query)
+
+    # mock judge：revenue 和 net income 等价，total assets 不等价
+    def mock_judge(predicted, expected):
+        if predicted == expected:
+            return True
+        return False
+
+    mock_judge_obj = MagicMock()
+    mock_judge_obj.judge = MagicMock(side_effect=mock_judge)
+
+    from pageindex_rag.benchmark.evaluator import BenchmarkEvaluator
+
+    evaluator = BenchmarkEvaluator(
+        pipeline=mock_pipeline,
+        dataset=mock_dataset,
+        judge=mock_judge_obj,
+    )
+
+    results = await evaluator.evaluate()
+
+    # 验证 evaluate() 返回格式
+    assert "accuracy" in results
+    assert "total" in results
+    assert "passed" in results
+    assert "failed_cases" in results
+
+    assert results["total"] == 3
+    assert results["passed"] == 2
+    assert abs(results["accuracy"] - 2 / 3) < 1e-9
+    assert len(results["failed_cases"]) == 1
+    assert results["failed_cases"][0]["question"] == "What was total assets?"
+    assert results["failed_cases"][0]["expected"] == "$500M"
+    assert results["failed_cases"][0]["predicted"] == "$300M"
+
+    # 验证 generate_report() 输出包含 accuracy
+    report = evaluator.generate_report(results)
+    assert "accuracy" in report.lower() or "Accuracy" in report
+    assert "2/3" in report or "66.67%" in report or "66.6" in report


### PR DESCRIPTION
## Summary

- 实现 `FinanceBenchDataset`：加载 HuggingFace PatronusAI/financebench，支持索引访问和唯一文档去重
- 实现 `AnswerEquivalenceJudge`：LLM 判定答案等价性（数值单位换算、超集判定）
- 实现 `BenchmarkEvaluator`：异步评估循环，生成 accuracy/failed_cases 报告

## Test plan

- [x] `test_load_financebench` — mock load_dataset，验证数据解析和去重
- [x] `test_answer_equivalence_judge` — mock ChatGPT_API，验证 YES/NO → True/False
- [x] `test_evaluation_report` — mock pipeline + judge，验证格式和报告内容
- [x] 全量测试 70/70 通过，无回归

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)