### PR TITLE
feat: implement FastAPI search and QA endpoints for Issue #13

### DIFF
--- a/pageindex_rag/api/app.py
+++ b/pageindex_rag/api/app.py
@@ -1,8 +1,10 @@
 """FastAPI application entry point for PageIndex RAG API."""
 
 from fastapi import FastAPI
-from pageindex_rag.api.routes import documents
+from pageindex_rag.api.routes import documents, search, qa
 
 app = FastAPI(title="PageIndex RAG API", version="0.1.0")
 
 app.include_router(documents.router, prefix="/documents", tags=["documents"])
+app.include_router(search.router, prefix="/search", tags=["search"])
+app.include_router(qa.router, prefix="/qa", tags=["qa"])

--- a/pageindex_rag/api/routes/documents.py
+++ b/pageindex_rag/api/routes/documents.py
@@ -41,6 +41,15 @@ def get_ingestion():
     return DocumentIngestion(store, searcher, cfg)
 
 
+def get_tree_searcher():
+    """Default tree searcher dependency. Override in tests via app.dependency_overrides."""
+    from pageindex_rag.retrieval.tree_search import TreeSearcher
+    from pageindex_rag.config import get_config
+
+    cfg = get_config()
+    return TreeSearcher(cfg)
+
+
 # ---------- Pydantic schemas ----------
 
 class MetadataUpdateRequest(BaseModel):
@@ -48,6 +57,10 @@ class MetadataUpdateRequest(BaseModel):
     company: Optional[str] = None
     fiscal_year: Optional[str] = None
     filing_type: Optional[str] = None
+
+
+class QueryRequest(BaseModel):
+    query: str
 
 
 # ---------- Endpoints ----------
@@ -145,3 +158,39 @@ def update_metadata(
     if not updated:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found.")
     return {"doc_id": doc_id, "updated": True}
+
+
+@router.post("/{doc_id}/search")
+async def search_document_tree(
+    doc_id: str,
+    request: QueryRequest,
+    store=Depends(get_document_store),
+    tree_searcher=Depends(get_tree_searcher),
+):
+    """在单个文档的树结构中搜索相关节点。"""
+    doc = store.get(doc_id)
+    if doc is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found.")
+
+    tree = doc.get("tree_json") or doc.get("tree")
+    result = await tree_searcher.search(request.query, tree)
+
+    node_ids = result.get("node_list", [])
+
+    # 从树结构中提取节点信息
+    nodes = []
+    if node_ids:
+        from pageindex.utils import get_nodes
+        all_nodes = get_nodes(tree)
+        node_map = {n["node_id"]: n for n in all_nodes}
+
+        for nid in node_ids:
+            if nid in node_map:
+                node = node_map[nid]
+                nodes.append({
+                    "node_id": nid,
+                    "title": node.get("title", ""),
+                    "summary": node.get("summary"),
+                })
+
+    return {"doc_id": doc_id, "nodes": nodes}

--- a/pageindex_rag/api/routes/qa.py
+++ b/pageindex_rag/api/routes/qa.py
@@ -1,0 +1,84 @@
+"""FastAPI routes for QA endpoints."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+
+router = APIRouter()
+
+
+# ---------- Dependency factories ----------
+
+def get_rag_pipeline():
+    """Default RAG pipeline dependency. Override in tests via app.dependency_overrides."""
+    from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+    from pageindex_rag.retrieval.tree_search import TreeSearcher
+    from pageindex_rag.retrieval.node_extractor import NodeContentExtractor
+    from pageindex_rag.search.router import DocumentSearchRouter
+    from pageindex_rag.search.description_search import DescriptionSearcher
+    from pageindex_rag.search.metadata_search import MetadataSearcher
+    from pageindex_rag.search.semantic_search import SemanticSearcher
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from pageindex_rag.storage.models import Base
+    from pageindex_rag.storage.document_store import DocumentStore
+    from pageindex_rag.config import get_config
+
+    cfg = get_config()
+    engine = create_engine(cfg.database_url)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    store = DocumentStore(Session)
+
+    tree_searcher = TreeSearcher(cfg)
+    node_extractor = NodeContentExtractor(store)
+
+    description_searcher = DescriptionSearcher(store)
+    metadata_searcher = MetadataSearcher(store)
+    semantic_searcher = SemanticSearcher(cfg)
+    search_router = DocumentSearchRouter(
+        description_searcher=description_searcher,
+        metadata_searcher=metadata_searcher,
+        semantic_searcher=semantic_searcher,
+        strategy="combined",
+    )
+
+    return RAGPipeline(
+        document_store=store,
+        tree_searcher=tree_searcher,
+        node_extractor=node_extractor,
+        search_router=search_router,
+        config=cfg,
+    )
+
+
+# ---------- Pydantic schemas ----------
+
+class QARequest:
+    """Request schema for QA endpoint (using raw dict for flexibility)."""
+    # In FastAPI, we can use dict directly or define Pydantic model
+    pass
+
+
+# ---------- Endpoints ----------
+
+@router.post("")
+async def answer_question(
+    request: dict,
+    rag_pipeline=Depends(get_rag_pipeline),
+):
+    """执行完整 RAG 问答，支持单文档和跨文档模式。
+
+    请求体格式:
+    {
+        "query": "问题",
+        "doc_id": "pi-xxx"  // 可选，不指定则跨文档
+    }
+    """
+    query = request.get("query", "")
+    doc_id = request.get("doc_id")
+
+    result = await rag_pipeline.query(query, doc_id)
+    return result

--- a/pageindex_rag/api/routes/search.py
+++ b/pageindex_rag/api/routes/search.py
@@ -1,0 +1,90 @@
+"""FastAPI routes for cross-document search endpoints."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+# ---------- Dependency factories ----------
+
+def get_search_router():
+    """Default search router dependency. Override in tests via app.dependency_overrides."""
+    from pageindex_rag.search.router import DocumentSearchRouter
+    from pageindex_rag.search.description_search import DescriptionSearcher
+    from pageindex_rag.search.metadata_search import MetadataSearcher
+    from pageindex_rag.search.semantic_search import SemanticSearcher
+    from pageindex_rag.storage.document_store import DocumentStore
+    from pageindex_rag.config import get_config
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from pageindex_rag.storage.models import Base
+
+    cfg = get_config()
+    engine = create_engine(cfg.database_url)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    store = DocumentStore(Session)
+
+    description_searcher = DescriptionSearcher(store)
+    metadata_searcher = MetadataSearcher(store)
+    semantic_searcher = SemanticSearcher(cfg)
+
+    return DocumentSearchRouter(
+        description_searcher=description_searcher,
+        metadata_searcher=metadata_searcher,
+        semantic_searcher=semantic_searcher,
+        strategy="combined",
+    )
+
+
+def get_document_store():
+    """Default document store dependency. Override in tests via app.dependency_overrides."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from pageindex_rag.storage.models import Base
+    from pageindex_rag.storage.document_store import DocumentStore
+    from pageindex_rag.config import get_config
+
+    cfg = get_config()
+    engine = create_engine(cfg.database_url)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return DocumentStore(Session)
+
+
+# ---------- Pydantic schemas ----------
+
+class SearchRequest(BaseModel):
+    query: str
+
+
+class SearchResult(BaseModel):
+    doc_id: str
+    score: float
+    metadata: dict
+
+
+# ---------- Endpoints ----------
+
+@router.post("", response_model=dict)
+async def search_documents(
+    request: SearchRequest,
+    search_router=Depends(get_search_router),
+):
+    """跨文档搜索，返回匹配的文档列表。"""
+    doc_ids = await search_router.search(request.query)
+
+    results = []
+    for doc_id in doc_ids:
+        results.append({
+            "doc_id": doc_id,
+            "score": 1.0,  # TODO: implement real scoring
+            "metadata": {}
+        })
+
+    return {"results": results}

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -1,0 +1,273 @@
+"""Tests for FastAPI search and QA endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pageindex_rag.api.app import app
+from pageindex_rag.api.routes.search import get_search_router
+from pageindex_rag.api.routes.documents import get_document_store, get_tree_searcher
+from pageindex_rag.api.routes.qa import get_rag_pipeline
+
+SAMPLE_DOC_ID = "pi-12345678-1234-1234-1234-123456789abc"
+SAMPLE_DOC_ID_2 = "pi-87654321-4321-4321-4321-cba987654321"
+
+SAMPLE_DOC = {
+    "doc_id": SAMPLE_DOC_ID,
+    "doc_name": "report.pdf",
+    "pdf_path": "/tmp/report.pdf",
+    "tree": {
+        "title": "Report",
+        "node_id": "0000",
+        "start_index": 1,
+        "end_index": 10,
+        "nodes": [
+            {
+                "title": "Chapter 1",
+                "node_id": "0001",
+                "start_index": 1,
+                "end_index": 5,
+                "summary": "Introduction",
+                "nodes": [],
+            },
+            {
+                "title": "Chapter 2",
+                "node_id": "0002",
+                "start_index": 6,
+                "end_index": 10,
+                "summary": "Analysis",
+                "nodes": [],
+            },
+        ],
+    },
+    "created_at": "2024-01-01T00:00:00",
+    "doc_description": "A test report",
+    "company": "TestCo",
+    "fiscal_year": "2023",
+    "filing_type": "10-K",
+}
+
+
+@pytest.fixture
+def mock_search_router():
+    router = MagicMock()
+    router.search = AsyncMock(return_value=[SAMPLE_DOC_ID, SAMPLE_DOC_ID_2])
+    return router
+
+
+@pytest.fixture
+def mock_store():
+    store = MagicMock()
+    store.get.return_value = SAMPLE_DOC
+    return store
+
+
+@pytest.fixture
+def mock_tree_searcher():
+    searcher = MagicMock()
+    searcher.search = AsyncMock(
+        return_value={
+            "thinking": "Search reasoning",
+            "node_list": ["0001", "0002"],
+        }
+    )
+    return searcher
+
+
+@pytest.fixture
+def mock_rag_pipeline():
+    pipeline = MagicMock()
+    pipeline.query = AsyncMock(
+        return_value={
+            "answer": "This is a test answer.",
+            "sources": [
+                {
+                    "doc_id": SAMPLE_DOC_ID,
+                    "node_id": "0001",
+                    "page_range": "1-5",
+                }
+            ],
+        }
+    )
+    return pipeline
+
+
+@pytest.fixture
+def client_search(mock_search_router):
+    app.dependency_overrides[get_search_router] = lambda: mock_search_router
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_documents(mock_store, mock_tree_searcher):
+    app.dependency_overrides[get_document_store] = lambda: mock_store
+    app.dependency_overrides[get_tree_searcher] = lambda: mock_tree_searcher
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_qa(mock_rag_pipeline):
+    app.dependency_overrides[get_rag_pipeline] = lambda: mock_rag_pipeline
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ---------- POST /search ----------
+
+class TestSearchEndpoint:
+    def test_search_returns_200(self, client_search):
+        response = client_search.post("/search", json={"query": "test question"})
+        assert response.status_code == 200
+
+    def test_search_returns_results(self, client_search):
+        response = client_search.post("/search", json={"query": "test question"})
+        data = response.json()
+        assert "results" in data
+        assert isinstance(data["results"], list)
+
+    def test_search_returns_doc_ids(self, client_search):
+        response = client_search.post("/search", json={"query": "test question"})
+        data = response.json()
+        doc_ids = [r["doc_id"] for r in data["results"]]
+        assert SAMPLE_DOC_ID in doc_ids
+        assert SAMPLE_DOC_ID_2 in doc_ids
+
+    def test_search_calls_search_router(self, client_search, mock_search_router):
+        client_search.post("/search", json={"query": "test question"})
+        mock_search_router.search.assert_called_once_with("test question")
+
+
+# ---------- POST /documents/{doc_id}/search ----------
+
+class TestTreeSearchEndpoint:
+    def test_tree_search_returns_200(self, client_documents):
+        response = client_documents.post(
+            f"/documents/{SAMPLE_DOC_ID}/search",
+            json={"query": "test question"},
+        )
+        assert response.status_code == 200
+
+    def test_tree_search_returns_doc_id(self, client_documents):
+        response = client_documents.post(
+            f"/documents/{SAMPLE_DOC_ID}/search",
+            json={"query": "test question"},
+        )
+        data = response.json()
+        assert data["doc_id"] == SAMPLE_DOC_ID
+
+    def test_tree_search_returns_nodes(self, client_documents):
+        response = client_documents.post(
+            f"/documents/{SAMPLE_DOC_ID}/search",
+            json={"query": "test question"},
+        )
+        data = response.json()
+        assert "nodes" in data
+        assert isinstance(data["nodes"], list)
+
+    def test_tree_search_returns_node_details(self, client_documents):
+        response = client_documents.post(
+            f"/documents/{SAMPLE_DOC_ID}/search",
+            json={"query": "test question"},
+        )
+        data = response.json()
+        nodes = data["nodes"]
+        assert len(nodes) == 2
+        assert nodes[0]["node_id"] == "0001"
+        assert nodes[0]["title"] == "Chapter 1"
+        assert nodes[0]["summary"] == "Introduction"
+        assert nodes[1]["node_id"] == "0002"
+        assert nodes[1]["title"] == "Chapter 2"
+
+    def test_tree_search_nonexistent_doc_returns_404(self, client_documents, mock_store):
+        mock_store.get.return_value = None
+        response = client_documents.post(
+            "/documents/pi-nonexistent/search",
+            json={"query": "test question"},
+        )
+        assert response.status_code == 404
+
+    def test_tree_search_calls_tree_searcher(self, client_documents, mock_tree_searcher):
+        client_documents.post(
+            f"/documents/{SAMPLE_DOC_ID}/search",
+            json={"query": "test question"},
+        )
+        mock_tree_searcher.search.assert_called_once()
+        call_args = mock_tree_searcher.search.call_args
+        assert call_args.args[0] == "test question"
+
+
+# ---------- POST /qa ----------
+
+class TestQAEndpointMultiDoc:
+    def test_qa_multi_doc_returns_200(self, client_qa):
+        response = client_qa.post(
+            "/qa",
+            json={"query": "test question"},
+        )
+        assert response.status_code == 200
+
+    def test_qa_multi_doc_returns_answer(self, client_qa):
+        response = client_qa.post(
+            "/qa",
+            json={"query": "test question"},
+        )
+        data = response.json()
+        assert "answer" in data
+        assert data["answer"] == "This is a test answer."
+
+    def test_qa_multi_doc_returns_sources(self, client_qa):
+        response = client_qa.post(
+            "/qa",
+            json={"query": "test question"},
+        )
+        data = response.json()
+        assert "sources" in data
+        assert isinstance(data["sources"], list)
+
+    def test_qa_multi_doc_source_structure(self, client_qa):
+        response = client_qa.post(
+            "/qa",
+            json={"query": "test question"},
+        )
+        data = response.json()
+        sources = data["sources"]
+        assert len(sources) == 1
+        assert sources[0]["doc_id"] == SAMPLE_DOC_ID
+        assert sources[0]["node_id"] == "0001"
+        assert sources[0]["page_range"] == "1-5"
+
+    def test_qa_multi_doc_calls_pipeline_without_doc_id(self, client_qa, mock_rag_pipeline):
+        client_qa.post("/qa", json={"query": "test question"})
+        mock_rag_pipeline.query.assert_called_once_with("test question", None)
+
+
+class TestQAEndpointSingleDoc:
+    def test_qa_single_doc_returns_200(self, client_qa):
+        response = client_qa.post(
+            "/qa",
+            json={"query": "test question", "doc_id": SAMPLE_DOC_ID},
+        )
+        assert response.status_code == 200
+
+    def test_qa_single_doc_returns_answer(self, client_qa):
+        response = client_qa.post(
+            "/qa",
+            json={"query": "test question", "doc_id": SAMPLE_DOC_ID},
+        )
+        data = response.json()
+        assert "answer" in data
+
+    def test_qa_single_doc_calls_pipeline_with_doc_id(self, client_qa, mock_rag_pipeline):
+        client_qa.post(
+            "/qa",
+            json={"query": "test question", "doc_id": SAMPLE_DOC_ID},
+        )
+        mock_rag_pipeline.query.assert_called_once_with("test question", SAMPLE_DOC_ID)


### PR DESCRIPTION
## Summary

- 实现 `POST /search` — 跨文档搜索，返回匹配文档列表
- 实现 `POST /documents/{doc_id}/search` — 单文档树搜索，返回相关节点
- 实现 `POST /qa` — 完整 RAG 问答，支持单/多文档模式
- 更新 `app.py` 挂载新路由

## Test plan

- [x] 18 个端点测试全部通过（覆盖所有新端点）
- [x] 全量测试 109/109 通过，无回归

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)