### PR TITLE
feat: implement full FinanceBench benchmark runner (Issue #17)

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+FinanceBench 全量基准测试脚本。
+
+运行 150 题测试，生成完整报告到 results/financebench_report.json。
+
+用法：
+    python scripts/run_benchmark.py [--limit N] [--output PATH]
+
+环境变量：
+    CHATGPT_API_KEY: OpenAI API Key
+    DATABASE_URL: PostgreSQL 连接字符串
+    CHROMA_PERSIST_DIR: ChromaDB 持久化目录
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# 添加项目根目录到路径
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pageindex_rag.benchmark.evaluator import AnswerEquivalenceJudge, BenchmarkEvaluator
+from pageindex_rag.benchmark.financebench import FinanceBenchDataset
+from pageindex_rag.config import get_config
+from pageindex_rag.ingestion.ingest import DocumentIngestion
+from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+from pageindex_rag.retrieval.node_extractor import NodeContentExtractor
+from pageindex_rag.retrieval.tree_search import TreeSearcher
+from pageindex_rag.search.metadata_search import MetadataSearcher
+from pageindex_rag.search.router import DocumentSearchRouter
+from pageindex_rag.search.semantic_search import SemanticSearcher
+from pageindex_rag.storage.document_store import DocumentStore
+
+
+class EnhancedBenchmarkEvaluator(BenchmarkEvaluator):
+    """增强的评估器，记录每题的详细信息。"""
+
+    async def evaluate(self, limit: int = None) -> dict:
+        """
+        对 dataset 中每题调用 pipeline.query()，用 judge 判定是否正确。
+        返回包含每题详细信息的评估结果。
+        """
+        total = len(self.dataset) if limit is None else min(limit, len(self.dataset))
+        passed = 0
+        failed_cases = []
+        question_results = []
+
+        for idx in range(total):
+            item = self.dataset[idx]
+            question = item["question"]
+            expected = item["answer"]
+            doc_name = item.get("doc_name", "")
+            company = item.get("company", "")
+            fiscal_year = item.get("fiscal_year", "")
+            filing_type = item.get("filing_type", "")
+
+            print(f"[{idx + 1}/{total}] {company} {fiscal_year} {filing_type}: {question[:50]}...")
+
+            # 调用 pipeline 获取答案
+            try:
+                result = await self.pipeline.query(question)
+                predicted = result.get("answer", "")
+                sources = result.get("sources", [])
+                doc_ids = [s.get("doc_id", "") for s in sources]
+                node_ids = [s.get("node_id", "") for s in sources]
+            except Exception as e:
+                print(f"  ❌ Error: {e}")
+                predicted = ""
+                doc_ids = []
+                node_ids = []
+
+            # 判定等价性
+            is_correct = self.judge.judge(predicted, expected)
+
+            question_result = {
+                "index": idx,
+                "question": question,
+                "expected_answer": expected,
+                "predicted_answer": predicted,
+                "is_correct": is_correct,
+                "doc_name": doc_name,
+                "company": company,
+                "fiscal_year": fiscal_year,
+                "filing_type": filing_type,
+                "evidence_nodes": node_ids,
+                "doc_ids": doc_ids,
+            }
+            question_results.append(question_result)
+
+            if is_correct:
+                passed += 1
+                print(f"  ✓ Correct")
+            else:
+                failed_cases.append({
+                    "index": idx,
+                    "question": question,
+                    "expected": expected,
+                    "predicted": predicted,
+                    "doc_name": doc_name,
+                    "doc_ids": doc_ids,
+                })
+                print(f"  ✗ Wrong")
+
+        accuracy = passed / total if total > 0 else 0.0
+
+        return {
+            "accuracy": accuracy,
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+            "failed_cases": failed_cases,
+            "question_results": question_results,
+        }
+
+    def generate_detailed_report(self, results: dict) -> dict:
+        """生成详细的 JSON 报告。"""
+        return {
+            "timestamp": datetime.now().isoformat(),
+            "summary": {
+                "accuracy": results["accuracy"],
+                "total": results["total"],
+                "passed": results["passed"],
+                "failed": results["failed"],
+                "target": 0.987,
+                "target_met": results["accuracy"] >= 0.987,
+            },
+            "question_results": results["question_results"],
+            "failed_cases": results["failed_cases"],
+        }
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="FinanceBench 全量基准测试")
+    parser.add_argument("--limit", type=int, default=None, help="限制测试题目数量")
+    parser.add_argument("--output", type=str, default="results/financebench_report.json", help="输出报告路径")
+    args = parser.parse_args()
+
+    # 检查环境变量
+    if not os.getenv("CHATGPT_API_KEY"):
+        print("错误: 需要设置 CHATGPT_API_KEY 环境变量")
+        sys.exit(1)
+
+    print("=" * 60)
+    print("FinanceBench 全量基准测试")
+    print("=" * 60)
+
+    # 初始化
+    config = get_config()
+    store = DocumentStore(config=config)
+
+    # 搜索器
+    semantic_searcher = SemanticSearcher(config=config)
+    semantic_searcher.load_index()
+
+    metadata_searcher = MetadataSearcher(store=store)
+
+    # 路由器（使用优化后的权重）
+    router = DocumentSearchRouter(
+        semantic_searcher=semantic_searcher,
+        metadata_searcher=metadata_searcher,
+        strategy="combined",
+        weights={"semantic": 2.0, "metadata": 1.5, "description": 1.0},
+    )
+
+    # 树搜索器
+    tree_searcher = TreeSearcher(config)
+
+    # 节点提取器
+    node_extractor = NodeContentExtractor(store=store)
+
+    # Pipeline
+    pipeline = RAGPipeline(
+        document_store=store,
+        tree_searcher=tree_searcher,
+        node_extractor=node_extractor,
+        search_router=router,
+        config=config,
+    )
+
+    # 数据集
+    dataset = FinanceBenchDataset()
+    limit = args.limit or len(dataset)
+    print(f"\n数据集大小: {len(dataset)} 题")
+    print(f"测试题目数: {limit} 题")
+    print(f"目标准确率: 98.7%")
+
+    # 评估器
+    judge = AnswerEquivalenceJudge(config=config)
+    evaluator = EnhancedBenchmarkEvaluator(pipeline, dataset, judge=judge, config=config)
+
+    # 运行评估
+    print("\n开始评估...")
+    print("-" * 60)
+    results = await evaluator.evaluate(limit=limit)
+
+    # 生成报告
+    print("\n" + "=" * 60)
+    print("评估完成!")
+    print("=" * 60)
+    print(f"准确率: {results['accuracy']:.2%}  ({results['passed']}/{results['total']})")
+    print(f"目标:   98.7%")
+    print(f"结果:   {'✓ 达标' if results['accuracy'] >= 0.987 else '✗ 未达标'}")
+
+    # 保存 JSON 报告
+    report = evaluator.generate_detailed_report(results)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"\n报告已保存到: {output_path}")
+
+    # 打印失败案例
+    if results["failed_cases"]:
+        print(f"\n失败案例 ({len(results['failed_cases'])} 条):")
+        for case in results["failed_cases"][:10]:
+            print(f"\n  [{case['index']}] {case['question'][:80]}")
+            print(f"      期望: {case['expected'][:80]}")
+            print(f"      预测: {case['predicted'][:80]}")
+        if len(results["failed_cases"]) > 10:
+            print(f"\n  ... 还有 {len(results['failed_cases']) - 10} 条失败案例")
+
+    # 按公司统计
+    company_stats = {}
+    for qr in results["question_results"]:
+        company = qr["company"]
+        if company not in company_stats:
+            company_stats[company] = {"total": 0, "passed": 0}
+        company_stats[company]["total"] += 1
+        if qr["is_correct"]:
+            company_stats[company]["passed"] += 1
+
+    print("\n按公司统计:")
+    for company, stats in sorted(company_stats.items()):
+        acc = stats["passed"] / stats["total"] if stats["total"] > 0 else 0
+        print(f"  {company}: {acc:.1%} ({stats['passed']}/{stats['total']})")
+
+    # 退出码
+    sys.exit(0 if results["accuracy"] >= 0.987 else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_full_benchmark.py
+++ b/tests/test_full_benchmark.py
@@ -1,0 +1,186 @@
+"""Tests for full FinanceBench benchmark (Issue #17)."""
+
+import json
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+
+
+@pytest.mark.skipif(not os.getenv("RUN_FULL_BENCHMARK"), reason="需要设置 RUN_FULL_BENCHMARK=1 运行全量测试")
+@pytest.mark.asyncio
+async def test_full_benchmark():
+    """运行全量 FinanceBench 测试，目标准确率 >= 98.7%。"""
+    import asyncio
+    import sys
+    from pathlib import Path
+
+    # 添加 scripts 目录到路径
+    sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+    # 运行 benchmark 脚本
+    result = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "scripts/run_benchmark.py",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await result.communicate()
+
+    # 检查退出码（0 表示达标，1 表示未达标）
+    assert result.returncode == 0, f"Benchmark failed:\n{stderr.decode()}"
+
+    # 检查报告文件
+    report_path = Path("results/financebench_report.json")
+    assert report_path.exists(), "报告文件未生成"
+
+    # 验证报告内容
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "summary" in report
+    assert report["summary"]["accuracy"] >= 0.987, f"准确率未达标: {report['summary']['accuracy']:.2%}"
+
+
+def test_benchmark_script_exists():
+    """测试 benchmark 脚本存在且可执行。"""
+    script_path = Path("scripts/run_benchmark.py")
+    assert script_path.exists(), "run_benchmark.py 不存在"
+
+
+def test_benchmark_report_schema():
+    """测试报告 schema 正确（使用模拟数据）。"""
+    from pageindex_rag.benchmark.evaluator import BenchmarkEvaluator
+    from pageindex_rag.benchmark.financebench import FinanceBenchDataset
+    from pageindex_rag.config import get_config
+
+    # 模拟数据
+    mock_results = {
+        "accuracy": 0.99,
+        "total": 150,
+        "passed": 148,
+        "failed": 2,
+        "failed_cases": [
+            {
+                "index": 10,
+                "question": "Test question",
+                "expected": "Expected answer",
+                "predicted": "Wrong answer",
+                "doc_name": "test.pdf",
+                "doc_ids": ["pi-test"],
+            }
+        ],
+        "question_results": [
+            {
+                "index": 0,
+                "question": "Test question",
+                "expected_answer": "Expected",
+                "predicted_answer": "Expected",
+                "is_correct": True,
+                "doc_name": "test.pdf",
+                "company": "TEST",
+                "fiscal_year": "2023",
+                "filing_type": "10-K",
+                "evidence_nodes": ["0001"],
+                "doc_ids": ["pi-test"],
+            }
+        ],
+    }
+
+    # 验证 schema
+    assert "accuracy" in mock_results
+    assert "total" in mock_results
+    assert "passed" in mock_results
+    assert "failed" in mock_results
+    assert "failed_cases" in mock_results
+    assert "question_results" in mock_results
+
+    # 验证 question_result schema
+    qr = mock_results["question_results"][0]
+    required_fields = [
+        "index", "question", "expected_answer", "predicted_answer",
+        "is_correct", "doc_name", "company", "fiscal_year",
+        "filing_type", "evidence_nodes", "doc_ids",
+    ]
+    for field in required_fields:
+        assert field in qr, f"Missing field: {field}"
+
+    # 验证 failed_case schema
+    fc = mock_results["failed_cases"][0]
+    required_fc_fields = ["index", "question", "expected", "predicted", "doc_name", "doc_ids"]
+    for field in required_fc_fields:
+        assert field in fc, f"Missing field in failed_case: {field}"
+
+
+def test_benchmark_report_format():
+    """测试报告 JSON 格式正确。"""
+    from datetime import datetime
+
+    # 模拟报告
+    report = {
+        "timestamp": datetime.now().isoformat(),
+        "summary": {
+            "accuracy": 0.987,
+            "total": 150,
+            "passed": 148,
+            "failed": 2,
+            "target": 0.987,
+            "target_met": True,
+        },
+        "question_results": [],
+        "failed_cases": [],
+    }
+
+    # 验证可序列化为 JSON
+    json_str = json.dumps(report, ensure_ascii=False, indent=2)
+    assert json_str
+
+    # 验证可以解析回来
+    parsed = json.loads(json_str)
+    assert parsed["summary"]["accuracy"] == 0.987
+    assert parsed["summary"]["target_met"] is True
+
+
+@pytest.mark.asyncio
+async def test_enhanced_evaluator_records_node_ids():
+    """测试增强评估器记录 evidence_nodes。"""
+    from unittest.mock import AsyncMock
+    from pageindex_rag.benchmark.evaluator import AnswerEquivalenceJudge
+    from scripts.run_benchmark import EnhancedBenchmarkEvaluator
+
+    # Mock pipeline
+    mock_pipeline = AsyncMock()
+    mock_pipeline.query.return_value = {
+        "answer": "Test answer",
+        "sources": [
+            {"doc_id": "pi-001", "node_id": "0001", "page_range": "1-5"},
+            {"doc_id": "pi-002", "node_id": "0002", "page_range": "6-10"},
+        ],
+    }
+
+    # Mock judge
+    mock_judge = MagicMock()
+    mock_judge.judge.return_value = True
+
+    # Mock dataset
+    mock_dataset = [
+        {
+            "question": "Test question?",
+            "answer": "Test answer",
+            "doc_name": "test.pdf",
+            "company": "TEST",
+            "fiscal_year": "2023",
+            "filing_type": "10-K",
+        }
+    ]
+
+    evaluator = EnhancedBenchmarkEvaluator(
+        pipeline=mock_pipeline,
+        dataset=mock_dataset,
+        judge=mock_judge,
+    )
+
+    results = await evaluator.evaluate()
+
+    # 验证记录了 node_ids
+    qr = results["question_results"][0]
+    assert qr["evidence_nodes"] == ["0001", "0002"]
+    assert qr["doc_ids"] == ["pi-001", "pi-002"]


### PR DESCRIPTION
## Summary

实现全量 FinanceBench 基准测试框架，支持 150 题测试和详细报告生成。

### 核心功能

**`scripts/run_benchmark.py`**
- 运行全量 150 题测试（支持 `--limit N` 小规模测试）
- 使用优化后的权重（semantic=2.0, metadata=1.5, description=1.0）
- 生成详细 JSON 报告到 `results/financebench_report.json`
- 按 company 统计准确率
- 显示失败案例分析

**报告格式**
```json
{
  "timestamp": "2026-02-28T...",
  "summary": {
    "accuracy": 0.987,
    "total": 150,
    "passed": 148,
    "failed": 2,
    "target": 0.987,
    "target_met": true
  },
  "question_results": [
    {
      "index": 0,
      "question": "...",
      "expected_answer": "...",
      "predicted_answer": "...",
      "is_correct": true,
      "doc_name": "...",
      "company": "...",
      "fiscal_year": "2023",
      "filing_type": "10-K",
      "evidence_nodes": ["0001", "0002"],
      "doc_ids": ["pi-xxx"]
    }
  ],
  "failed_cases": [...]
}
```

**EnhancedBenchmarkEvaluator**
- 继承 `BenchmarkEvaluator`
- 记录每题详细信息（evidence_nodes, doc_ids）
- 生成详细 JSON 报告

## Test plan

- [x] 4 个单元测试通过
- [x] 全量 117 个测试通过
- [x] `test_full_benchmark` 支持 `RUN_FULL_BENCHMARK=1` 触发

## Usage

```bash
# 小规模测试
python scripts/run_benchmark.py --limit 10

# 全量测试
python scripts/run_benchmark.py

# 通过 pytest 触发
RUN_FULL_BENCHMARK=1 pytest tests/test_full_benchmark.py
```

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)