### PR TITLE
fix: resolve issue #13/#16/#17/#18 runtime and benchmark blockers

### DIFF
--- a/pageindex_rag/api/routes/qa.py
+++ b/pageindex_rag/api/routes/qa.py
@@ -35,8 +35,8 @@ def get_rag_pipeline():
     tree_searcher = TreeSearcher(cfg)
     node_extractor = NodeContentExtractor(store)
 
-    description_searcher = DescriptionSearcher(store)
-    metadata_searcher = MetadataSearcher(store)
+    description_searcher = DescriptionSearcher(store, cfg)
+    metadata_searcher = MetadataSearcher(store, cfg)
     semantic_searcher = SemanticSearcher(cfg)
     search_router = DocumentSearchRouter(
         description_searcher=description_searcher,

--- a/pageindex_rag/api/routes/search.py
+++ b/pageindex_rag/api/routes/search.py
@@ -30,8 +30,8 @@ def get_search_router():
     Session = sessionmaker(bind=engine)
     store = DocumentStore(Session)
 
-    description_searcher = DescriptionSearcher(store)
-    metadata_searcher = MetadataSearcher(store)
+    description_searcher = DescriptionSearcher(store, cfg)
+    metadata_searcher = MetadataSearcher(store, cfg)
     semantic_searcher = SemanticSearcher(cfg)
 
     return DocumentSearchRouter(

--- a/pageindex_rag/pipeline/answer_generator.py
+++ b/pageindex_rag/pipeline/answer_generator.py
@@ -12,9 +12,20 @@ class AnswerGenerator:
         复用 pageindex/utils.py 中的 ChatGPT_API_async。
         """
 
+        # 兼容旧调用：dict[node_id -> content]
+        if isinstance(nodes_content, dict):
+            normalized_nodes = [
+                {"node_id": node_id, "content": content, "page_range": ""}
+                for node_id, content in nodes_content.items()
+            ]
+        else:
+            normalized_nodes = nodes_content or []
+
         # 构建上下文
         context_parts = []
-        for node in nodes_content:
+        for node in normalized_nodes:
+            if not isinstance(node, dict):
+                continue
             content = node.get("content", "")
             node_id = node.get("node_id", "")
             page_range = node.get("page_range", "")
@@ -57,8 +68,7 @@ ANSWERING GUIDELINES FOR FINANCIAL REPORTS:
 
 Please provide your answer:"""
 
-        messages = [{"role": "user", "content": prompt}]
-
         model = getattr(self.config, "model", "gpt-4o-mini")
-        answer = await ChatGPT_API_async(messages, model=model)
+        api_key = getattr(self.config, "openai_api_key", "")
+        answer = await ChatGPT_API_async(model, prompt, api_key)
         return answer

--- a/pageindex_rag/pipeline/rag_pipeline.py
+++ b/pageindex_rag/pipeline/rag_pipeline.py
@@ -11,6 +11,55 @@ class RAGPipeline:
         self.search_router = search_router
         self.config = config
 
+    @staticmethod
+    def _normalize_node_ids(tree_search_result) -> list[str]:
+        """Accept both TreeSearcher result dict and plain node_id list."""
+        if isinstance(tree_search_result, dict):
+            node_list = tree_search_result.get("node_list", [])
+            return node_list if isinstance(node_list, list) else []
+        if isinstance(tree_search_result, list):
+            return tree_search_result
+        return []
+
+    @staticmethod
+    def _extract_doc_id(search_result_item) -> str | None:
+        """Accept both router result dict items and plain doc_id strings."""
+        if isinstance(search_result_item, str):
+            return search_result_item
+        if isinstance(search_result_item, dict):
+            return search_result_item.get("doc_id")
+        return None
+
+    @staticmethod
+    def _build_nodes_content(doc: dict, node_ids: list[str], extracted_nodes) -> list[dict]:
+        """Convert extractor output to a normalized list for answer generation."""
+        if isinstance(extracted_nodes, list):
+            return extracted_nodes
+
+        if not isinstance(extracted_nodes, dict):
+            return []
+
+        tree = doc.get("tree_json") or doc.get("tree")
+        node_meta_map = {}
+        if tree:
+            from pageindex.utils import get_nodes
+
+            node_meta_map = {n.get("node_id"): n for n in get_nodes(tree)}
+
+        normalized = []
+        for node_id in node_ids:
+            content = extracted_nodes.get(node_id, "")
+            meta = node_meta_map.get(node_id, {})
+            start = meta.get("start_index")
+            end = meta.get("end_index")
+            page_range = f"{start}-{end}" if start is not None and end is not None else ""
+            normalized.append({
+                "node_id": node_id,
+                "content": content,
+                "page_range": page_range,
+            })
+        return normalized
+
     async def query(self, query: str, doc_id: str = None) -> dict:
         """
         执行 RAG 查询。
@@ -29,12 +78,16 @@ class RAGPipeline:
                 return {"answer": "未找到指定文档。", "sources": []}
 
             tree = doc.get("tree_json") or doc.get("tree")
-            node_ids = await self.tree_searcher.search(query, tree)
+            tree_search_result = await self.tree_searcher.search(query, tree)
+            node_ids = self._normalize_node_ids(tree_search_result)
 
             if not node_ids:
                 return {"answer": "在文档中未找到相关内容。", "sources": []}
 
-            nodes_content = self.node_extractor.extract(doc_id, node_ids)
+            extracted_nodes = self.node_extractor.extract(doc_id, node_ids)
+            nodes_content = self._build_nodes_content(doc, node_ids, extracted_nodes)
+            if not nodes_content:
+                return {"answer": "在文档中未找到相关内容。", "sources": []}
             answer = await answer_generator.generate(query, nodes_content)
 
             sources = []
@@ -61,18 +114,24 @@ class RAGPipeline:
             all_sources = []
 
             for result in search_results:
-                result_doc_id = result.get("doc_id")
+                result_doc_id = self._extract_doc_id(result)
+                if not result_doc_id:
+                    continue
                 doc = self.document_store.get(result_doc_id)
                 if doc is None:
                     continue
 
                 tree = doc.get("tree_json") or doc.get("tree")
-                node_ids = await self.tree_searcher.search(query, tree)
+                tree_search_result = await self.tree_searcher.search(query, tree)
+                node_ids = self._normalize_node_ids(tree_search_result)
 
                 if not node_ids:
                     continue
 
-                nodes_content = self.node_extractor.extract(result_doc_id, node_ids)
+                extracted_nodes = self.node_extractor.extract(result_doc_id, node_ids)
+                nodes_content = self._build_nodes_content(doc, node_ids, extracted_nodes)
+                if not nodes_content:
+                    continue
                 all_nodes_content.extend(nodes_content)
 
                 for node in nodes_content:

--- a/scripts/compare_optimization.py
+++ b/scripts/compare_optimization.py
@@ -13,37 +13,43 @@
 import argparse
 import asyncio
 import os
-from statistics import mean
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from pageindex_rag.benchmark.evaluator import AnswerEquivalenceJudge, BenchmarkEvaluator
 from pageindex_rag.benchmark.financebench import FinanceBenchDataset
 from pageindex_rag.config import get_config
-from pageindex_rag.ingestion.ingest import DocumentIngestion
 from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
-from pageindex_rag.retrieval.tree_search import TreeSearcher, SEC_FINANCIAL_REPORT_EXPERT
+from pageindex_rag.retrieval.node_extractor import NodeContentExtractor
+from pageindex_rag.retrieval.tree_search import TreeSearcher
+from pageindex_rag.search.metadata_search import MetadataSearcher
 from pageindex_rag.search.router import DocumentSearchRouter
 from pageindex_rag.search.semantic_search import SemanticSearcher
 from pageindex_rag.storage.document_store import DocumentStore
+from pageindex_rag.storage.models import Base
 
 
 async def evaluate_baseline(config, dataset, limit, store):
     """评估 baseline（无 expert knowledge，默认权重）。"""
     semantic_searcher = SemanticSearcher(config=config)
-    semantic_searcher.load_index()
+    metadata_searcher = MetadataSearcher(document_store=store, config=config)
 
     router = DocumentSearchRouter(
         semantic_searcher=semantic_searcher,
+        metadata_searcher=metadata_searcher,
         strategy="combined",
         # 使用等权重模拟优化前
         weights={"semantic": 1.0, "metadata": 1.0, "description": 1.0},
     )
 
     tree_searcher = TreeSearcher(config)
+    node_extractor = NodeContentExtractor(store)
 
     pipeline = RAGPipeline(
         document_store=store,
         tree_searcher=tree_searcher,
-        node_extractor=None,  # 需要实现或 mock
+        node_extractor=node_extractor,
         search_router=router,
         config=config,
     )
@@ -58,21 +64,23 @@ async def evaluate_baseline(config, dataset, limit, store):
 async def evaluate_optimized(config, dataset, limit, store):
     """评估优化后（注入 expert knowledge，优化权重）。"""
     semantic_searcher = SemanticSearcher(config=config)
-    semantic_searcher.load_index()
+    metadata_searcher = MetadataSearcher(document_store=store, config=config)
 
     router = DocumentSearchRouter(
         semantic_searcher=semantic_searcher,
+        metadata_searcher=metadata_searcher,
         strategy="combined",
         # 使用优化后的权重
         weights={"semantic": 2.0, "metadata": 1.5, "description": 1.0},
     )
 
     tree_searcher = TreeSearcher(config)
+    node_extractor = NodeContentExtractor(store)
 
     pipeline = RAGPipeline(
         document_store=store,
         tree_searcher=tree_searcher,
-        node_extractor=None,
+        node_extractor=node_extractor,
         search_router=router,
         config=config,
     )
@@ -96,7 +104,10 @@ async def main():
         return
 
     config = get_config()
-    store = DocumentStore(config=config)
+    engine = create_engine(config.database_url)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    store = DocumentStore(SessionLocal)
     dataset = FinanceBenchDataset()
 
     print(f"评估 {min(args.limit, len(dataset))} 题...")

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -24,10 +24,12 @@ from pathlib import Path
 # 添加项目根目录到路径
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from pageindex_rag.benchmark.evaluator import AnswerEquivalenceJudge, BenchmarkEvaluator
 from pageindex_rag.benchmark.financebench import FinanceBenchDataset
 from pageindex_rag.config import get_config
-from pageindex_rag.ingestion.ingest import DocumentIngestion
 from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
 from pageindex_rag.retrieval.node_extractor import NodeContentExtractor
 from pageindex_rag.retrieval.tree_search import TreeSearcher
@@ -35,6 +37,7 @@ from pageindex_rag.search.metadata_search import MetadataSearcher
 from pageindex_rag.search.router import DocumentSearchRouter
 from pageindex_rag.search.semantic_search import SemanticSearcher
 from pageindex_rag.storage.document_store import DocumentStore
+from pageindex_rag.storage.models import Base
 
 
 class EnhancedBenchmarkEvaluator(BenchmarkEvaluator):
@@ -151,13 +154,14 @@ async def main():
 
     # 初始化
     config = get_config()
-    store = DocumentStore(config=config)
+    engine = create_engine(config.database_url)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    store = DocumentStore(SessionLocal)
 
     # 搜索器
     semantic_searcher = SemanticSearcher(config=config)
-    semantic_searcher.load_index()
-
-    metadata_searcher = MetadataSearcher(store=store)
+    metadata_searcher = MetadataSearcher(document_store=store, config=config)
 
     # 路由器（使用优化后的权重）
     router = DocumentSearchRouter(
@@ -171,7 +175,7 @@ async def main():
     tree_searcher = TreeSearcher(config)
 
     # 节点提取器
-    node_extractor = NodeContentExtractor(store=store)
+    node_extractor = NodeContentExtractor(store)
 
     # Pipeline
     pipeline = RAGPipeline(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -90,15 +90,12 @@ def test_deploy_script_contains_required_commands():
     deploy = Path("scripts/deploy.sh")
     content = deploy.read_text()
 
-    required_commands = [
-        "rsync",
-        "docker-compose",
-        "curl",
-        "health",
-    ]
-
-    for command in required_commands:
-        assert command in content, f"deploy.sh 缺少命令: {command}"
+    assert "rsync" in content, "deploy.sh 缺少命令: rsync"
+    assert "curl" in content, "deploy.sh 缺少命令: curl"
+    assert "health" in content, "deploy.sh 缺少关键字: health"
+    assert (
+        "docker compose" in content or "docker-compose" in content
+    ), "deploy.sh 缺少 docker compose/docker-compose 命令"
 
 
 def test_deploy_script_has_correct_server():

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -137,3 +137,77 @@ async def test_no_relevant_doc(mock_document_store, mock_tree_searcher, mock_nod
     assert "sources" in result
     assert result["sources"] == []
     assert "未找到" in result["answer"] or "no" in result["answer"].lower()
+
+
+@pytest.mark.asyncio
+async def test_single_doc_pipeline_handles_tree_search_dict_and_extractor_map():
+    """单文档模式兼容 tree_search dict 输出与 extractor map 输出。"""
+    from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+
+    document_store = MagicMock()
+    document_store.get.return_value = {
+        "doc_id": "pi-test-123",
+        "tree": {
+            "title": "Doc",
+            "node_id": "0000",
+            "start_index": 1,
+            "end_index": 2,
+            "nodes": [
+                {"node_id": "0001", "title": "S1", "start_index": 1, "end_index": 1, "nodes": []},
+                {"node_id": "0002", "title": "S2", "start_index": 2, "end_index": 2, "nodes": []},
+            ],
+        },
+    }
+    tree_searcher = MagicMock()
+    tree_searcher.search = AsyncMock(return_value={"thinking": "...", "node_list": ["0001", "0002"]})
+    node_extractor = MagicMock()
+    node_extractor.extract.return_value = {"0001": "text-1", "0002": "text-2"}
+
+    with patch("pageindex_rag.pipeline.answer_generator.ChatGPT_API_async", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = "answer"
+        pipeline = RAGPipeline(document_store, tree_searcher, node_extractor)
+        result = await pipeline.query("Q", doc_id="pi-test-123")
+
+    assert result["answer"] == "answer"
+    assert len(result["sources"]) == 2
+    assert result["sources"][0]["node_id"] == "0001"
+    assert result["sources"][0]["page_range"] == "1-1"
+    assert result["sources"][1]["node_id"] == "0002"
+    assert result["sources"][1]["page_range"] == "2-2"
+
+
+@pytest.mark.asyncio
+async def test_multi_doc_pipeline_handles_router_doc_id_list():
+    """多文档模式兼容 search_router 返回 list[str]。"""
+    from pageindex_rag.pipeline.rag_pipeline import RAGPipeline
+
+    document_store = MagicMock()
+    document_store.get.side_effect = lambda doc_id: {
+        "doc_id": doc_id,
+        "tree": {
+            "title": "Doc",
+            "node_id": "0000",
+            "start_index": 1,
+            "end_index": 1,
+            "nodes": [{"node_id": "0001", "title": "S1", "start_index": 1, "end_index": 1, "nodes": []}],
+        },
+    }
+    tree_searcher = MagicMock()
+    tree_searcher.search = AsyncMock(return_value={"thinking": "...", "node_list": ["0001"]})
+    node_extractor = MagicMock()
+    node_extractor.extract.return_value = {"0001": "text"}
+    search_router = MagicMock()
+    search_router.search = AsyncMock(return_value=["pi-test-123", "pi-test-456"])
+
+    with patch("pageindex_rag.pipeline.answer_generator.ChatGPT_API_async", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = "answer"
+        pipeline = RAGPipeline(
+            document_store=document_store,
+            tree_searcher=tree_searcher,
+            node_extractor=node_extractor,
+            search_router=search_router,
+        )
+        result = await pipeline.query("Q")
+
+    assert result["answer"] == "answer"
+    assert [s["doc_id"] for s in result["sources"]] == ["pi-test-123", "pi-test-456"]


### PR DESCRIPTION
## Summary
- fix RAG pipeline contract mismatches across tree search / router / node extractor outputs
- fix AnswerGenerator async API call signature and normalize legacy extractor output
- fix API dependency wiring for DescriptionSearcher and MetadataSearcher config injection
- fix benchmark scripts initialization (DocumentStore session factory, NodeContentExtractor init, remove invalid load_index calls)
- fix deployment test to support both `docker compose` and `docker-compose`
- add regression tests for pipeline contract compatibility

## Validation
- pytest -q
- pytest -q tests/test_rag_pipeline.py tests/test_api_search.py tests/test_api_documents.py tests/test_search_router.py tests/test_deployment.py
- python3 -m py_compile pageindex_rag/pipeline/answer_generator.py pageindex_rag/pipeline/rag_pipeline.py pageindex_rag/api/routes/search.py pageindex_rag/api/routes/qa.py scripts/run_benchmark.py scripts/compare_optimization.py
- smoke run: scripts/run_benchmark.py --limit 1 (starts successfully; fails only with dummy API key 401)
- smoke run: scripts/compare_optimization.py --limit 1 (starts successfully; fails only with dummy API key 401)
